### PR TITLE
[0.3.2] Fix profile dialog in safari

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "private": true,
     "proxy": "http://localhost:5000/",
     "engines": {

--- a/client/src/containers/ProfileDialog/DialogContent.jsx
+++ b/client/src/containers/ProfileDialog/DialogContent.jsx
@@ -38,7 +38,6 @@ const useStyles = makeStyles((theme) => ({
     flexWrap: 'wrap',
   },
   characteristics: {
-    flex: 0,
     display: 'flex',
     flexDirection: 'row',
     [theme.breakpoints.up('lg')]: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer-express",
-    "version": "0.3.1",
+    "version": "0.3.2",
     "engines": {
         "node": "12.13.1",
         "yarn": "1.19.2"


### PR DESCRIPTION
`Flex: 0` causes safari to collapse the characteristic fields