### PR TITLE
[0.4.0] Full Dice notation, List re-ordering, extra config, and improved UI/UX

### DIFF
--- a/api/models/dice.js
+++ b/api/models/dice.js
@@ -1,5 +1,5 @@
 /**
- * A class used to represent a dice value (e.g: D3, D6)
+ * A class used to represent a single dice (e.g: D3, D6)
  */
 export class Dice {
   /**

--- a/api/models/dice.js
+++ b/api/models/dice.js
@@ -32,6 +32,10 @@ export class Dice {
     return 1 - this.getProbability(target);
   }
 
+  toString() {
+    return `D${this.sides}`;
+  }
+
   /**
    * Build a `Dice` class or `Number` by parsing a value
    * @param {string|Dice|int|float} val The value to parse

--- a/api/models/dice.js
+++ b/api/models/dice.js
@@ -31,32 +31,32 @@ export class Dice {
   getInverseProbability(target) {
     return 1 - this.getProbability(target);
   }
+
+  /**
+   * Build a `Dice` class or `Number` by parsing a value
+   * @param {string|Dice|int|float} val The value to parse
+   */
+  static parse(val) {
+    if (val instanceof Dice) {
+      return val;
+    }
+    if (typeof val === 'string') {
+      const match = val.match(/^[dD](\d+)$/);
+      if (match && match[1]) {
+        return new Dice(match[1]);
+      }
+    }
+    const num = Number(val);
+    if (Number.isNaN(num)) {
+      throw new Error(`Invalid Value or Dice (${val})`);
+    }
+    return num;
+  }
 }
 
-/**
- * Get a `Dice` class or `Number` for a given value
- * @param {string|Dice|int|float} val The value to parse
- */
-export const parseDice = (val) => {
-  if (val instanceof Dice) {
-    return val;
-  }
-  if (typeof val === 'string') {
-    const match = val.match(/^[dD](\d+)$/);
-    if (match && match[1]) {
-      return new Dice(match[1]);
-    }
-  }
-  const num = Number(val);
-  if (Number.isNaN(num)) {
-    throw new Error(`Invalid Value or Dice (${val})`);
-  }
-  return num;
-};
-
 /** A 3 sided dice */
-export const D3 = new Dice(3);
+const D3 = new Dice(3);
 /** A 6 sided dice */
-export const D6 = new Dice(6);
+const D6 = new Dice(6);
 
-export { Dice as default };
+export { Dice as default, D3, D6 };

--- a/api/models/diceValue.js
+++ b/api/models/diceValue.js
@@ -33,6 +33,7 @@ class DiceValue {
    */
   static parse(val) {
     if (val instanceof this) return val;
+    if (val instanceof Dice) return new this([val]);
     let items = String(val).split(/\+/);
     items = items.reduce((acc, item) => {
       const i = item.trim();

--- a/api/models/diceValue.js
+++ b/api/models/diceValue.js
@@ -19,9 +19,6 @@ class DiceValue {
 
     this.additions = additions;
     this.subtractions = subtractions;
-    if (this.average < 0) {
-      throw new Error('You cannot have a negative average');
-    }
   }
 
   /**
@@ -35,7 +32,7 @@ class DiceValue {
     const averageSubtractions = this.subtractions.reduce((acc, item) => (
       (item instanceof Dice) ? acc + item.average : acc + Number(item)
     ), 0);
-    return averageAditions - averageSubtractions;
+    return Math.max(averageAditions - averageSubtractions, 0);
   }
 
   /**

--- a/api/models/diceValue.js
+++ b/api/models/diceValue.js
@@ -1,40 +1,51 @@
-import { Dice, parseDice } from './dice';
+import { Dice } from './dice';
 
-export class DiceValue {
+/**
+ * A class used to represent a combination of Dice and Constants (e.g: D3, 2D6, D6+2, etc.)
+ */
+class DiceValue {
+  /**
+   * @param {[Dice,Number]} items
+   */
   constructor(items) {
     const dice = [];
-    const constants = [];
+    let additions = 0;
     items.forEach((item) => {
       if (item instanceof Dice) dice.push(item);
-      else if (!Number.isNaN(Number(item))) constants.push(Number(item));
+      else if (!Number.isNaN(Number(item))) additions += Number(item);
       else throw new Error(`Invalid item ${item} passed to DiceValue`);
     });
     this.dice = dice;
-    this.constants = constants;
+    this.additions = additions;
   }
 
-  /** The average of this dice value */
+  /**
+   * The average of this dice value (combination of the average of each dice,
+   * summed with the additions)
+   * */
   get average() {
-    const diceAverage = this.dice.reduce((acc, die) => acc + die.average, 0);
-    const constants = this.constants.reduce((acc, c) => acc + c, 0);
-    return diceAverage + constants;
+    return this.dice.reduce((acc, die) => acc + die.average, 0) + this.additions;
+  }
+
+  /**
+   * Build a `DiceValue` class by parsing a value
+   * @param {string|DiceValue|int|float} val The value to parse
+   */
+  static parse(val) {
+    if (val instanceof this) return val;
+    let items = String(val).split(/\+/);
+    items = items.reduce((acc, item) => {
+      const i = item.trim();
+      const multiDiceMatch = i.match(/^(\d+)([dD]\d+)$/);
+      if (multiDiceMatch && multiDiceMatch[1] && multiDiceMatch[2]) {
+        acc.push(...[...Array(Number(multiDiceMatch[1]))].map(() => Dice.parse(multiDiceMatch[2])));
+      } else {
+        acc.push(Dice.parse(i));
+      }
+      return acc;
+    }, []);
+    return new this(items);
   }
 }
 
-export const parseDiceValue = (val) => {
-  if (val instanceof DiceValue) {
-    return val;
-  }
-  let items = String(val).split(/\+/);
-  items = items.reduce((acc, item) => {
-    const i = item.trim();
-    const multiDiceMatch = i.match(/^(\d+)([dD]\d+)$/);
-    if (multiDiceMatch && multiDiceMatch[1] && multiDiceMatch[2]) {
-      acc.push(...[...Array(Number(multiDiceMatch[1]))].map(() => parseDice(multiDiceMatch[2])));
-    } else {
-      acc.push(parseDice(i));
-    }
-    return acc;
-  }, []);
-  return new DiceValue(items);
-};
+export { DiceValue as default };

--- a/api/models/diceValue.js
+++ b/api/models/diceValue.js
@@ -33,7 +33,7 @@ class DiceValue {
     const averageSubtractions = this.subtractions.reduce((acc, item) => (
       (item instanceof Dice) ? acc + item.average : acc + Number(item)
     ), 0);
-    return Math.max(averageAditions - averageSubtractions, 0);
+    return averageAditions - averageSubtractions;
   }
 
   /**

--- a/api/models/diceValue.js
+++ b/api/models/diceValue.js
@@ -5,7 +5,8 @@ import { Dice } from './dice';
  */
 class DiceValue {
   /**
-   * @param {[Dice,Number]} items
+   * @param {[Dice,Number]} additions
+   * @param {[Dice,Number]} subtractions
    */
   constructor(additions = [], subtractions = []) {
     const validateItem = (item) => {

--- a/api/models/diceValue.js
+++ b/api/models/diceValue.js
@@ -1,0 +1,40 @@
+import { Dice, parseDice } from './dice';
+
+export class DiceValue {
+  constructor(items) {
+    const dice = [];
+    const constants = [];
+    items.forEach((item) => {
+      if (item instanceof Dice) dice.push(item);
+      else if (!Number.isNaN(Number(item))) constants.push(Number(item));
+      else throw new Error(`Invalid item ${item} passed to DiceValue`);
+    });
+    this.dice = dice;
+    this.constants = constants;
+  }
+
+  /** The average of this dice value */
+  get average() {
+    const diceAverage = this.dice.reduce((acc, die) => acc + die.average, 0);
+    const constants = this.constants.reduce((acc, c) => acc + c, 0);
+    return diceAverage + constants;
+  }
+}
+
+export const parseDiceValue = (val) => {
+  if (val instanceof DiceValue) {
+    return val;
+  }
+  let items = String(val).split(/\+/);
+  items = items.reduce((acc, item) => {
+    const i = item.trim();
+    const multiDiceMatch = i.match(/^(\d+)([dD]\d+)$/);
+    if (multiDiceMatch && multiDiceMatch[1] && multiDiceMatch[2]) {
+      acc.push(...[...Array(Number(multiDiceMatch[1]))].map(() => parseDice(multiDiceMatch[2])));
+    } else {
+      acc.push(parseDice(i));
+    }
+    return acc;
+  }, []);
+  return new DiceValue(items);
+};

--- a/api/models/modifiers/Bonus.js
+++ b/api/models/modifiers/Bonus.js
@@ -1,12 +1,12 @@
 import { Characteristics as C } from '../../constants';
-import { Dice, parseDice } from '../dice';
+import DiceValue from '../diceValue';
 import { numberOption } from './ModifierOptions';
 import BaseModifier from './BaseModifier';
 
 export default class Bonus extends BaseModifier {
   constructor({ characteristic, bonus }) {
     super({ characteristic });
-    this.bonus = parseDice(bonus);
+    this.bonus = DiceValue.parse(bonus);
   }
 
   static get name() {
@@ -28,11 +28,7 @@ export default class Bonus extends BaseModifier {
     };
   }
 
-  // eslint-disable-next-line no-unused-vars
-  resolve(owner) {
-    if (this.bonus instanceof Dice) {
-      return this.bonus.average;
-    }
-    return this.bonus;
+  resolve() {
+    return this.bonus.average;
   }
 }

--- a/api/models/modifiers/ConditionalBonus.js
+++ b/api/models/modifiers/ConditionalBonus.js
@@ -1,8 +1,9 @@
 import { Characteristics as C, getCharacteristic } from '../../constants';
-import { parseDice, D6 } from '../dice';
+import { D6 } from '../dice';
 import {
   numberOption, booleanOption, rollOption, choiceOption,
 } from './ModifierOptions';
+import DiceValue from '../diceValue';
 import BaseModifier from './BaseModifier';
 import Bonus from './Bonus';
 
@@ -12,7 +13,7 @@ export default class ConditionalBonus extends BaseModifier {
   }) {
     super({ characteristic });
     this.on = Number(on);
-    this.bonus = parseDice(bonus);
+    this.bonus = DiceValue.parse(bonus);
     this.unmodified = Boolean(unmodified);
 
     const c = getCharacteristic(bonusToCharacteristic);

--- a/api/models/modifiers/Exploding.js
+++ b/api/models/modifiers/Exploding.js
@@ -1,5 +1,6 @@
 import { Characteristics as C } from '../../constants';
-import { D6, Dice, parseDice } from '../dice';
+import { D6 } from '../dice';
+import DiceValue from '../diceValue';
 import { numberOption, booleanOption, rollOption } from './ModifierOptions';
 import BaseModifier from './BaseModifier';
 
@@ -9,7 +10,7 @@ export default class Exploding extends BaseModifier {
   }) {
     super({ characteristic });
     this.on = Number(on);
-    this.extraHits = parseDice(extraHits);
+    this.extraHits = DiceValue.parse(extraHits);
     this.unmodified = Boolean(unmodified);
   }
 
@@ -36,13 +37,10 @@ export default class Exploding extends BaseModifier {
 
   // eslint-disable-next-line no-unused-vars
   resolve(owner) {
-    return D6.getProbability(this.on) * this.getExtraHits();
+    return D6.getProbability(this.on) * this.getExtra();
   }
 
-  getExtraHits() {
-    if (this.extraHits instanceof Dice) {
-      return this.extraHits.average;
-    }
-    return this.extraHits;
+  getExtra() {
+    return this.extraHits.average;
   }
 }

--- a/api/models/modifiers/LeaderBonus.js
+++ b/api/models/modifiers/LeaderBonus.js
@@ -1,6 +1,6 @@
 import { Characteristics as C } from '../../constants';
 import { numberOption } from './ModifierOptions';
-import { Dice, parseDice } from '../dice';
+import DiceValue from '../diceValue';
 import BaseModifier from './BaseModifier';
 import Bonus from './Bonus';
 
@@ -8,7 +8,7 @@ export default class LeaderBonus extends BaseModifier {
   constructor({ characteristic, numLeaders = 1, bonus = 1 }) {
     super({ characteristic });
     this.numLeaders = Number(numLeaders);
-    this.bonus = parseDice(bonus);
+    this.bonus = DiceValue.parse(bonus);
   }
 
   static get name() {
@@ -37,10 +37,7 @@ export default class LeaderBonus extends BaseModifier {
   }
 
   getBonus() {
-    if (this.bonus instanceof Dice) {
-      return this.bonus.average;
-    }
-    return this.bonus;
+    return this.bonus.average;
   }
 
   getAsBonusModifier() {

--- a/api/models/modifiers/MortalWounds.js
+++ b/api/models/modifiers/MortalWounds.js
@@ -1,5 +1,6 @@
 import { Characteristics as C } from '../../constants';
-import { D6, Dice, parseDice } from '../dice';
+import { D6 } from '../dice';
+import DiceValue from '../diceValue';
 import BaseModifier from './BaseModifier';
 import { numberOption, booleanOption, rollOption } from './ModifierOptions';
 
@@ -9,7 +10,7 @@ export default class MortalWounds extends BaseModifier {
   }) {
     super({ characteristic });
     this.on = Number(on);
-    this.mortalWounds = parseDice(mortalWounds);
+    this.mortalWounds = DiceValue.parse(mortalWounds);
     this.unmodified = Boolean(unmodified);
     this.inAddition = Boolean(inAddition);
   }
@@ -46,9 +47,6 @@ export default class MortalWounds extends BaseModifier {
   }
 
   getMortalWounds() {
-    if (this.mortalWounds instanceof Dice) {
-      return this.mortalWounds.average;
-    }
-    return this.mortalWounds;
+    return this.mortalWounds.average;
   }
 }

--- a/api/models/weaponProfile.js
+++ b/api/models/weaponProfile.js
@@ -1,7 +1,8 @@
 /* eslint-disable no-underscore-dangle */
 import { ModifierManager, MODIFIERS as m } from './modifiers';
 import { Characteristics as C } from '../constants';
-import { D6, Dice, parseDice } from './dice';
+import { D6 } from './dice';
+import DiceValue from './diceValue';
 
 /**
  * A class representing a single weapon profile belonging to a unit
@@ -9,20 +10,20 @@ import { D6, Dice, parseDice } from './dice';
 class WeaponProfile {
   /**
    * @param {int} numModels The number of models that have this profile
-   * @param {int|Dice} attacks The number of attacks per model
+   * @param {int|DiceValue} attacks The number of attacks per model
    * @param {int} toHit The amount you have to roll >= to hit
    * @param {int} toWound The amount you have to roll >= to wound
    * @param {int} rend The amount of rend the profile has
-   * @param {int|Dice} damage The amount of damage per wound this profile does
+   * @param {int|DiceValue} damage The amount of damage per wound this profile does
    * @param {object[]} modifiers The array of modifiers the profile has
    */
   constructor(numModels, attacks, toHit, toWound, rend, damage, modifiers = []) {
     this.numModels = Number(numModels);
-    this.attacks = parseDice(attacks);
+    this.attacks = DiceValue.parse(attacks);
     this.toHit = Number(toHit);
     this.toWound = Number(toWound);
     this.rend = Number(rend);
-    this.damage = parseDice(damage);
+    this.damage = DiceValue.parse(damage);
     this.modifiers = new ModifierManager(modifiers);
   }
 
@@ -31,10 +32,7 @@ class WeaponProfile {
    * @param {bool} unmodified Whether you want the unmodified characteristic or not
    */
   getAttacks(unmodified = false) {
-    let { attacks } = this;
-    if (attacks instanceof Dice) {
-      attacks = attacks.average;
-    }
+    let attacks = this.attacks.average;
     if (!unmodified) attacks += this.resolveStackableModifier(m.BONUS, C.ATTACKS);
     return attacks;
   }
@@ -74,10 +72,7 @@ class WeaponProfile {
    * @param {bool} unmodified Whether you want the unmodified characteristic or not
    */
   getDamage(unmodified = false) {
-    let { damage } = this;
-    if (damage instanceof Dice) damage = damage.average;
-    else damage = Number(damage);
-
+    let damage = this.damage.average;
     if (!unmodified) damage += this.resolveStackableModifier(m.BONUS, C.DAMAGE);
     return Math.max(damage, 0);
   }

--- a/api/models/weaponProfile.js
+++ b/api/models/weaponProfile.js
@@ -34,7 +34,7 @@ class WeaponProfile {
   getAttacks(unmodified = false) {
     let attacks = this.attacks.average;
     if (!unmodified) attacks += this.resolveStackableModifier(m.BONUS, C.ATTACKS);
-    return attacks;
+    return Math.max(attacks, 1);
   }
 
   /**
@@ -74,7 +74,7 @@ class WeaponProfile {
   getDamage(unmodified = false) {
     let damage = this.damage.average;
     if (!unmodified) damage += this.resolveStackableModifier(m.BONUS, C.DAMAGE);
-    return Math.max(damage, 0);
+    return Math.max(damage, 1);
   }
 
   /**

--- a/api/tests/testDice.js
+++ b/api/tests/testDice.js
@@ -1,0 +1,78 @@
+/* eslint-disable no-undef */
+import assert from 'assert';
+import { Dice, D3, D6 } from '../models/dice';
+import { round } from './utils';
+
+describe('Dice', () => {
+  describe('Average', () => {
+    it('should return correct average (D3)', () => {
+      assert.equal(new Dice(3).average, 2);
+    });
+    it('should return correct average (D6)', () => {
+      assert.equal(new Dice(6).average, 3.5);
+    });
+    it('should return correct average (D12)', () => {
+      assert.equal(new Dice(12).average, 6.5);
+    });
+    it('should return correct average (D20)', () => {
+      assert.equal(new Dice(20).average, 10.5);
+    });
+  });
+
+  describe('Probability', () => {
+    it('should return correct probability for 1+ roll for D3', () => {
+      assert.equal(round(new Dice(3).getProbability(1), 2), 1);
+    });
+    it('should return correct probability for 2+ roll for D3', () => {
+      assert.equal(round(new Dice(3).getProbability(2), 2), 0.667);
+    });
+    it('should return correct probability for 3+ roll for D3', () => {
+      assert.equal(round(new Dice(3).getProbability(3), 2), 0.333);
+    });
+    it('should return correct probability for 1+ roll for D6', () => {
+      assert.equal(round(new Dice(6).getProbability(1), 2), 1);
+    });
+    it('should return correct probability for 4+ roll for D6', () => {
+      assert.equal(round(new Dice(6).getProbability(4), 2), 0.5);
+    });
+    it('should return correct probability for 6+ roll for D6', () => {
+      assert.equal(round(new Dice(6).getProbability(6), 2), 0.167);
+    });
+  });
+
+  describe('Inverse Probability', () => {
+    it('should return correct probability for < 1 roll for D3', () => {
+      assert.equal(round(new Dice(3).getInverseProbability(1), 2), 0);
+    });
+    it('should return correct probability for < 2 roll for D3', () => {
+      assert.equal(round(new Dice(3).getInverseProbability(2), 2), 0.333);
+    });
+    it('should return correct probability for < 3 roll for D3', () => {
+      assert.equal(round(new Dice(3).getInverseProbability(3), 2), 0.667);
+    });
+    it('should return correct probability for < 1 roll for D6', () => {
+      assert.equal(round(new Dice(6).getInverseProbability(1), 2), 0);
+    });
+    it('should return correct probability for < 4 roll for D6', () => {
+      assert.equal(round(new Dice(6).getInverseProbability(4), 2), 0.5);
+    });
+    it('should return correct probability for < 6 roll for D6', () => {
+      assert.equal(round(new Dice(6).getInverseProbability(6), 2), 0.833);
+    });
+  });
+
+
+  describe('Parse', () => {
+    it('should return correct parsed Dice (D3)', () => {
+      assert.equal(Dice.parse('D3').average, D3.average);
+      assert.equal(Dice.parse('d3').average, D3.average);
+    });
+    it('should return correct parsed Dice (D6)', () => {
+      assert.equal(Dice.parse('D6').average, D6.average);
+      assert.equal(Dice.parse('d6').average, D6.average);
+    });
+    it('should return correct parsed Dice (2)', () => {
+      assert.equal(Dice.parse('2'), 2);
+    });
+  });
+});

--- a/api/tests/testDiceValue.js
+++ b/api/tests/testDiceValue.js
@@ -1,0 +1,57 @@
+/* eslint-disable no-undef */
+import assert from 'assert';
+import DiceValue from '../models/diceValue';
+import { D3, D6 } from '../models/dice';
+
+describe('DiceValue', () => {
+  describe('Average', () => {
+    it('should return correct average (D3)', () => {
+      assert.equal(new DiceValue([D3]).average, 2);
+    });
+    it('should return correct average (D6)', () => {
+      assert.equal(new DiceValue([D6]).average, 3.5);
+    });
+    it('should return correct average (2D6)', () => {
+      assert.equal(new DiceValue([D6, D6]).average, 7);
+    });
+    it('should return correct average (D3+1)', () => {
+      assert.equal(new DiceValue([D3, 1]).average, 3);
+    });
+    it('should return correct average (2D6+2)', () => {
+      assert.equal(new DiceValue([D6, D6, 2]).average, 9);
+    });
+    it('should return correct average (2D6+D3+2)', () => {
+      assert.equal(new DiceValue([D6, D6, D3, 2]).average, 11);
+    });
+  });
+
+  describe('Parse', () => {
+    it('should return correct parsed DiceValue (D3)', () => {
+      assert.equal(DiceValue.parse('D3').average, new DiceValue([D3]).average);
+      assert.equal(DiceValue.parse('d3').average, new DiceValue([D3]).average);
+    });
+    it('should return correct parsed DiceValue (D6)', () => {
+      assert.equal(DiceValue.parse('D6').average, new DiceValue([D6]).average);
+      assert.equal(DiceValue.parse('d6').average, new DiceValue([D6]).average);
+    });
+    it('should return correct parsed DiceValue (2D6)', () => {
+      assert.equal(DiceValue.parse('2D6').average, new DiceValue([D6, D6]).average);
+      assert.equal(DiceValue.parse('2d6').average, new DiceValue([D6, D6]).average);
+      assert.equal(DiceValue.parse('D6 + D6').average, new DiceValue([D6, D6]).average);
+      assert.equal(DiceValue.parse('D6+d6').average, new DiceValue([D6, D6]).average);
+    });
+    it('should return correct parsed DiceValue (2D6+2)', () => {
+      assert.equal(DiceValue.parse('2D6+2').average, new DiceValue([D6, D6, 2]).average);
+      assert.equal(DiceValue.parse('2d6 + 2').average, new DiceValue([D6, D6, 2]).average);
+      assert.equal(DiceValue.parse('2 + D6 + D6').average, new DiceValue([D6, D6, 2]).average);
+      assert.equal(DiceValue.parse('D6+d6+2').average, new DiceValue([D6, D6, 2]).average);
+      assert.equal(DiceValue.parse('D6+D6+1+1').average, new DiceValue([D6, D6, 2]).average);
+    });
+    it('should return correct parsed DiceValue (2D6+D3+1)', () => {
+      assert.equal(DiceValue.parse('2D6+D3+1').average, new DiceValue([D6, D6, D3, 1]).average);
+      assert.equal(DiceValue.parse('d6+d6+d3+1').average, new DiceValue([D6, D6, D3, 1]).average);
+      assert.equal(DiceValue.parse('D6 + D6 + D3 + 1').average, new DiceValue([D6, D6, D3, 1]).average);
+      assert.equal(DiceValue.parse('1+d3+D6+d6').average, new DiceValue([D6, D6, D3, 1]).average);
+    });
+  });
+});

--- a/api/tests/testDiceValue.js
+++ b/api/tests/testDiceValue.js
@@ -4,7 +4,7 @@ import DiceValue from '../models/diceValue';
 import { D3, D6 } from '../models/dice';
 
 describe('DiceValue', () => {
-  describe('Average', () => {
+  describe('DiceValue.average', () => {
     it('should return correct average (D3)', () => {
       assert.equal(new DiceValue([D3]).average, 2);
     });
@@ -23,35 +23,60 @@ describe('DiceValue', () => {
     it('should return correct average (2D6+D3+2)', () => {
       assert.equal(new DiceValue([D6, D6, D3, 2]).average, 11);
     });
+    it('should return correct average (2D6-D3+2)', () => {
+      assert.equal(new DiceValue([D6, D6, 2], [D3]).average, 7);
+    });
+    it('should return correct average (2D6-2)', () => {
+      assert.equal(new DiceValue([D6, D6], [2]).average, 5);
+    });
   });
 
-  describe('Parse', () => {
+  describe('DiceValue.parse', () => {
     it('should return correct parsed DiceValue (D3)', () => {
-      assert.equal(DiceValue.parse('D3').average, new DiceValue([D3]).average);
-      assert.equal(DiceValue.parse('d3').average, new DiceValue([D3]).average);
+      const target = new DiceValue([D3]).average;
+      assert.equal(DiceValue.parse('D3').average, target);
+      assert.equal(DiceValue.parse('d3').average, target);
     });
     it('should return correct parsed DiceValue (D6)', () => {
-      assert.equal(DiceValue.parse('D6').average, new DiceValue([D6]).average);
-      assert.equal(DiceValue.parse('d6').average, new DiceValue([D6]).average);
+      const target = new DiceValue([D6]).average;
+      assert.equal(DiceValue.parse('D6').average, target);
+      assert.equal(DiceValue.parse('d6').average, target);
     });
     it('should return correct parsed DiceValue (2D6)', () => {
-      assert.equal(DiceValue.parse('2D6').average, new DiceValue([D6, D6]).average);
-      assert.equal(DiceValue.parse('2d6').average, new DiceValue([D6, D6]).average);
-      assert.equal(DiceValue.parse('D6 + D6').average, new DiceValue([D6, D6]).average);
-      assert.equal(DiceValue.parse('D6+d6').average, new DiceValue([D6, D6]).average);
+      const target = new DiceValue([D6, D6]).average;
+      assert.equal(DiceValue.parse('2D6').average, target);
+      assert.equal(DiceValue.parse('2d6').average, target);
+      assert.equal(DiceValue.parse('D6 + D6').average, target);
+      assert.equal(DiceValue.parse('D6+d6').average, target);
     });
     it('should return correct parsed DiceValue (2D6+2)', () => {
-      assert.equal(DiceValue.parse('2D6+2').average, new DiceValue([D6, D6, 2]).average);
-      assert.equal(DiceValue.parse('2d6 + 2').average, new DiceValue([D6, D6, 2]).average);
-      assert.equal(DiceValue.parse('2 + D6 + D6').average, new DiceValue([D6, D6, 2]).average);
-      assert.equal(DiceValue.parse('D6+d6+2').average, new DiceValue([D6, D6, 2]).average);
-      assert.equal(DiceValue.parse('D6+D6+1+1').average, new DiceValue([D6, D6, 2]).average);
+      const target = new DiceValue([D6, D6, 2]).average;
+      assert.equal(DiceValue.parse('2D6+2').average, target);
+      assert.equal(DiceValue.parse('2d6 + 2').average, target);
+      assert.equal(DiceValue.parse('2 + D6 + D6').average, target);
+      assert.equal(DiceValue.parse('D6+d6+2').average, target);
+      assert.equal(DiceValue.parse('D6+D6+1+1').average, target);
     });
     it('should return correct parsed DiceValue (2D6+D3+1)', () => {
-      assert.equal(DiceValue.parse('2D6+D3+1').average, new DiceValue([D6, D6, D3, 1]).average);
-      assert.equal(DiceValue.parse('d6+d6+d3+1').average, new DiceValue([D6, D6, D3, 1]).average);
-      assert.equal(DiceValue.parse('D6 + D6 + D3 + 1').average, new DiceValue([D6, D6, D3, 1]).average);
-      assert.equal(DiceValue.parse('1+d3+D6+d6').average, new DiceValue([D6, D6, D3, 1]).average);
+      const target = new DiceValue([D6, D6, D3, 1]).average;
+      assert.equal(DiceValue.parse('2D6+D3+1').average, target);
+      assert.equal(DiceValue.parse('d6+d6+d3+1').average, target);
+      assert.equal(DiceValue.parse('D6 + D6 + D3 + 1').average, target);
+      assert.equal(DiceValue.parse('1+d3+D6+d6').average, target);
+    });
+    it('should return correct parsed DiceValue (2D6+D3-1)', () => {
+      const target = new DiceValue([D6, D6, D3, 1]).average;
+      assert.equal(DiceValue.parse('2D6+D3+1').average, target);
+      assert.equal(DiceValue.parse('d6+d6+d3+1').average, target);
+      assert.equal(DiceValue.parse('D6 + D6 + D3 + 1').average, target);
+      assert.equal(DiceValue.parse('1+d3+D6+d6').average, target);
+    });
+    it('should return correct parsed DiceValue (2D6-D3+1)', () => {
+      const target = new DiceValue([D6, D6, 1], [D3]).average;
+      assert.equal(DiceValue.parse('2D6-D3+1').average, target);
+      assert.equal(DiceValue.parse('d6+d6-d3+1').average, target);
+      assert.equal(DiceValue.parse('D6 + D6 - D3 + 1').average, target);
+      assert.equal(DiceValue.parse('1-d3+D6+d6').average, target);
     });
   });
 });

--- a/api/tests/testUnits.js
+++ b/api/tests/testUnits.js
@@ -5,6 +5,7 @@ import { MODIFIERS as m } from '../models/modifiers';
 import { Characteristics as C } from '../constants';
 import { D6 } from '../models/dice';
 import { testUnit } from './utils';
+import DiceValue from '../models/diceValue';
 
 
 describe('Units', () => {
@@ -139,5 +140,12 @@ describe('Units', () => {
       ]),
     ]);
     testUnit(unit, [20.000, 17.778, 14.444, 11.111, 7.778, 4.444]);
+  });
+
+  describe('Rattling Gunners', () => {
+    const unit = new Unit('Rattling Gunners', [
+      new WeaponProfile(1, DiceValue.parse('2D6'), 4, 4, 1, 1, []),
+    ]);
+    testUnit(unit, [1.75, 1.75, 1.458, 1.167, 0.875, 0.583]);
   });
 });

--- a/api/tests/utils.js
+++ b/api/tests/utils.js
@@ -1,7 +1,6 @@
 /* eslint-disable no-undef */
+import assert from 'assert';
 import Target from '../models/target';
-
-const assert = require('assert');
 
 export const SAVES = [0, 6, 5, 4, 3, 2];
 

--- a/client/package.json
+++ b/client/package.json
@@ -23,6 +23,7 @@
         "@storybook/theming": "^5.2.6",
         "babel-plugin-import": "^1.13.0",
         "clsx": "^1.0.4",
+        "core-js": "^3.5.0",
         "cross-fetch": "^3.0.4",
         "eslint": "^6.6.0",
         "eslint-config-airbnb": "^18.0.1",
@@ -45,6 +46,7 @@
         "redux": "^4.0.4",
         "redux-persist": "^6.0.0",
         "redux-thunk": "^2.3.0",
+        "regenerator-runtime": "^0.13.3",
         "typeface-roboto": "^0.0.75",
         "use-debounce": "^3.2.0",
         "uuid": "^3.3.3"

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer",
-    "version": "0.3.3",
+    "version": "0.4.0",
     "private": true,
     "proxy": "http://localhost:5000/",
     "engines": {

--- a/client/src/actions/config.action.js
+++ b/client/src/actions/config.action.js
@@ -1,5 +1,10 @@
 export const TOGGLE_DARK_MODE = 'TOGGLE_DARK_MODE';
+export const TOGGLE_DESKTOP_GRAPH_LIST = 'TOGGLE_DESKTOP_GRAPH_LIST';
 
 export const toggleDarkMode = () => ({
   type: TOGGLE_DARK_MODE,
+});
+
+export const toggleDesktopGraphList = () => ({
+  type: TOGGLE_DESKTOP_GRAPH_LIST,
 });

--- a/client/src/actions/units.action.js
+++ b/client/src/actions/units.action.js
@@ -4,6 +4,7 @@ export const ADD_UNIT = 'ADD_UNIT';
 export const DELETE_UNIT = 'DELETE_UNIT';
 export const EDIT_UNIT_NAME = 'EDIT_UNIT_NAME';
 export const CLEAR_ALL_UNITS = 'CLEAR_ALL_UNITS';
+export const MOVE_UNIT = 'MOVE_UNIT';
 
 export const addUnit = (name, weapon_profiles = [DEFAULT_WEAPON_PROFILE]) => ({
   type: ADD_UNIT,
@@ -27,3 +28,9 @@ export const editUnitName = (unitId, name) => ({
 export const clearAllUnits = () => ({
   type: CLEAR_ALL_UNITS,
 });
+
+export const moveUnit = (index, newIndex) => ({
+  type: MOVE_UNIT,
+  index,
+  newIndex
+})

--- a/client/src/actions/weaponProfiles.action.js
+++ b/client/src/actions/weaponProfiles.action.js
@@ -2,6 +2,7 @@ export const TOGGLE_WEAPON_PROFILE = 'TOGGLE_WEAPON_PROFILE';
 export const EDIT_WEAPON_PROFILE = 'EDIT_WEAPON_PROFILE';
 export const ADD_WEAPON_PROFILE = 'ADD_WEAPON_PROFILE';
 export const DELETE_WEAPON_PROFILE = 'DELETE_WEAPON_PROFILE';
+export const MOVE_WEAPON_PROFILE = 'MOVE_WEAPON_PROFILE';
 
 export const toggleWeaponProfile = (id, unitId = 0) => ({
   type: TOGGLE_WEAPON_PROFILE,
@@ -37,3 +38,10 @@ export const deleteWeaponProfile = (id, unitId = 0) => ({
   id,
   unitId,
 });
+
+export const moveWeaponProfile = (index, newIndex, unitId = 0) => ({
+    type: MOVE_WEAPON_PROFILE,
+    index,
+    newIndex,
+    unitId,
+  });

--- a/client/src/components/ActionsDialog/ActionsDialog.jsx
+++ b/client/src/components/ActionsDialog/ActionsDialog.jsx
@@ -16,6 +16,7 @@ const ActionsDialog = ({
   open, actions, target, onClose,
 }) => {
   const classes = useStyles();
+  if (!actions || !actions.length) return null;
 
   return (
     <Dialog

--- a/client/src/components/AppBar/AppMenu.jsx
+++ b/client/src/components/AppBar/AppMenu.jsx
@@ -6,7 +6,7 @@ import {
 } from '@material-ui/core';
 import { MoreVert } from '@material-ui/icons';
 import { clearAllUnits, addUnit } from 'actions/units.action';
-import { toggleDarkMode } from 'actions/config.action';
+import { toggleDarkMode, toggleDesktopGraphList } from 'actions/config.action';
 import { connect } from 'react-redux';
 import ConfirmationDialog from 'components/ConfirmationDialog';
 import { useHistory, Route } from 'react-router-dom';
@@ -28,7 +28,7 @@ const useStyles = makeStyles((theme) => ({
  * A menu list containing various actions that can be performed
  */
 const AppMenu = ({
-  clearAllUnits, addNotification, toggleDarkMode, addUnit,
+  clearAllUnits, addNotification, toggleDarkMode, addUnit, toggleDesktopGraphList,
 }) => {
   const classes = useStyles();
   const history = useHistory();
@@ -102,6 +102,11 @@ const AppMenu = ({
             Beta
           </Typography>
         </MenuItem>
+        {!mobile && (
+          <MenuItem onClick={() => menuItemClick(toggleDesktopGraphList)}>
+            Toggle Graph List/Tabs
+          </MenuItem>
+        )}
         <Uploader
           onUpload={(data) => menuItemClick(() => onUnitUpload(data))}
           disabled={isUploadDisabled}
@@ -131,8 +136,10 @@ AppMenu.propTypes = {
   toggleDarkMode: PropTypes.func.isRequired,
   /** A function to call to add a new unit */
   addUnit: PropTypes.func.isRequired,
+  /** A function to call to toggle the desktop graph list */
+  toggleDesktopGraphList: PropTypes.func.isRequired,
 };
 
 export default connect(null, {
-  clearAllUnits, addNotification, toggleDarkMode, addUnit,
+  clearAllUnits, addNotification, toggleDarkMode, addUnit, toggleDesktopGraphList,
 })(AppMenu);

--- a/client/src/components/AppBar/AppMenu.jsx
+++ b/client/src/components/AppBar/AppMenu.jsx
@@ -4,7 +4,9 @@ import { makeStyles, useTheme } from '@material-ui/core/styles';
 import {
   Menu, MenuItem, IconButton, Typography, Button, useMediaQuery,
 } from '@material-ui/core';
-import { MoreVert } from '@material-ui/icons';
+import {
+  MoreVert, BarChart, ImportExport, BrightnessMedium, Delete,
+} from '@material-ui/icons';
 import { clearAllUnits, addUnit } from 'actions/units.action';
 import { toggleDarkMode, toggleDesktopGraphList } from 'actions/config.action';
 import { connect } from 'react-redux';
@@ -14,6 +16,7 @@ import { addNotification } from 'actions/notifications.action';
 import Uploader from 'components/Uploader';
 import { addUnitEnabled } from 'utils/unitHelpers';
 
+
 const useStyles = makeStyles((theme) => ({
   menu: {},
   icon: {
@@ -21,6 +24,9 @@ const useStyles = makeStyles((theme) => ({
   },
   caption: {
     paddingBottom: theme.spacing(1),
+  },
+  menuItemIcon: {
+    marginRight: theme.spacing(1),
   },
 }));
 
@@ -117,8 +123,12 @@ const AppMenu = ({
         open={Boolean(anchorEl)}
         onClose={handleMenuClose}
       >
-        <MenuItem onClick={() => setLocation(confirmPath)}>Clear Units</MenuItem>
+        <MenuItem onClick={() => setLocation(confirmPath)}>
+          <Delete className={classes.menuItemIcon} />
+          Clear Units
+        </MenuItem>
         <MenuItem onClick={() => menuItemClick(toggleDarkMode)}>
+          <BrightnessMedium className={classes.menuItemIcon} />
           <span>Toggle Dark Mode&nbsp;</span>
           <Typography variant="caption" color="secondary" className={classes.caption}>
             Beta
@@ -126,15 +136,19 @@ const AppMenu = ({
         </MenuItem>
         {!mobile && (
           <MenuItem onClick={() => menuItemClick(toggleDesktopGraphList)}>
+            <BarChart className={classes.menuItemIcon} />
             Toggle Graph List/Tabs
           </MenuItem>
         )}
         <Uploader
           onUpload={(data) => menuItemClick(() => onUnitUpload(data))}
           disabled={isUploadDisabled}
-          component={
-            <MenuItem disabled={isUploadDisabled}>Import Unit</MenuItem>
-          }
+          component={(
+            <MenuItem disabled={isUploadDisabled}>
+              <ImportExport className={classes.menuItemIcon} />
+              Import Unit
+            </MenuItem>
+          )}
         />
       </Menu>
       <Route path={confirmPath}>

--- a/client/src/components/AppBar/AppMenu.jsx
+++ b/client/src/components/AppBar/AppMenu.jsx
@@ -38,31 +38,53 @@ const AppMenu = ({
   const [anchorEl, setAnchorEl] = useState(null);
   const confirmPath = '/units/confirm';
 
+  /**
+   * Handle the on click event for the menu button (Open the menu)
+   * @param {object} event The event object passed from the DOM element caller
+   */
   const handleMenuClick = useCallback((event) => {
     setAnchorEl(event.currentTarget);
   }, []);
 
+  /** Handle closing the menu */
   const handleMenuClose = useCallback(() => {
     setAnchorEl(null);
   }, []);
 
+  /**
+   * Handle the onclick event for any given menu item
+   * @param {func} action The function to call for the given menu item
+   */
   const menuItemClick = useCallback((action) => {
     action();
     handleMenuClose();
   }, [handleMenuClose]);
 
+  /**
+   * Change the URL bar to a new location. This is used to display dialog boxes that
+   * retains proper navigation
+   * @param {string} newloc the new URL to set
+   */
   const setLocation = useCallback((newloc) => {
     handleMenuClose();
     history.push(newloc);
   }, [handleMenuClose, history]);
 
+  /**
+   * Handle the case when the confirm option is selected from the clear all units dialog
+   */
   const clearAllConfirmed = useCallback(() => {
     menuItemClick(clearAllUnits);
     addNotification({ message: 'All units cleared', variant: 'info' });
   }, [addNotification, clearAllUnits, menuItemClick]);
 
+  /** Is the upload menu item disabled or not */
   const isUploadDisabled = !addUnitEnabled();
 
+  /** The function to call when a file upload happens.
+   * In this case that would be importing the uploaded unit data
+   * @param {object} data the JSON from the uploaded unit
+   * */
   const onUnitUpload = useCallback((data) => {
     if (data && data.name && data.weapon_profiles) {
       addNotification({ message: 'Successfully imported unit', variant: 'success' });

--- a/client/src/components/DiceInput/DiceInput.jsx
+++ b/client/src/components/DiceInput/DiceInput.jsx
@@ -5,6 +5,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { TextField } from '@material-ui/core';
 import clsx from 'clsx';
+import _ from 'lodash';
 
 const useStyles = makeStyles({
   diceInput: {},
@@ -14,7 +15,7 @@ const useStyles = makeStyles({
  * An input component that can either controlled or uncontrolled.
  * This input component contains validation for correct dice inputs (e.g: D3, or 3)
  */
-const DiceInput = ({
+const DiceInput = React.memo(({
   label, value, onChange, className, required, errorCallback, ...other
 }) => {
   const classes = useStyles();
@@ -71,7 +72,7 @@ const DiceInput = ({
       {...other}
     />
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 DiceInput.defaultProps = {
   label: null,

--- a/client/src/components/DiceInput/DiceInput.jsx
+++ b/client/src/components/DiceInput/DiceInput.jsx
@@ -21,7 +21,9 @@ const DiceInput = ({
   const [error, setError] = useState(false);
   const [errorMessage, setErrorMessage] = useState(null);
 
-  const isDice = useCallback((val) => Boolean(String(val).match(/^[dD]\d+$/)), []);
+  const isDice = useCallback((val) => (
+    Boolean(String(val).replace(/\s/g, '').match(/^(?:\d*[dD]?\d+)(?:\+\d*[dD]?\d+)*$/))
+  ), []);
   const isValid = useCallback((val) => !Number.isNaN(Number(val)) || isDice(val), [isDice]);
 
   const setErrorState = useCallback((errMessage) => {

--- a/client/src/components/DiceInput/DiceInput.jsx
+++ b/client/src/components/DiceInput/DiceInput.jsx
@@ -23,7 +23,7 @@ const DiceInput = React.memo(({
   const [errorMessage, setErrorMessage] = useState(null);
 
   const isDice = useCallback((val) => (
-    Boolean(String(val).replace(/\s/g, '').match(/^(?:\d*[dD]?\d+)(?:\+\d*[dD]?\d+)*$/))
+    Boolean(String(val).replace(/\s/g, '').match(/^(?:\d*[dD]?\d+)(?:[+-]\d*[dD]?\d+)*$/))
   ), []);
   const isValid = useCallback((val) => !Number.isNaN(Number(val)) || isDice(val), [isDice]);
 

--- a/client/src/components/Graphs/BarGraph.jsx
+++ b/client/src/components/Graphs/BarGraph.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Label,
 } from 'recharts';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import clsx from 'clsx';
@@ -23,14 +23,23 @@ const BarGraph = ({
   const classes = useStyles();
   const theme = useTheme();
 
+  const xAxisLabel = (value) => (value === 'None' ? '-' : `${value}+`);
+
   return (
     <GraphContainer className={clsx(classes.graph, className)}>
       <BarChart
         data={results}
       >
         <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.graphs.grid} />
-        <XAxis dataKey="save" stroke={theme.palette.graphs.axis} />
-        <YAxis stroke={theme.palette.graphs.axis} />
+        <XAxis dataKey="save" stroke={theme.palette.graphs.axis} tickFormatter={xAxisLabel} />
+        <YAxis stroke={theme.palette.graphs.axis}>
+          <Label
+            value="Average Damage"
+            angle={-90}
+            position="insideLeft"
+            fill={theme.palette.graphs.axis}
+          />
+        </YAxis>
         <Tooltip content={<GraphTooltip />} cursor={{ fill: theme.palette.graphs.grid }} />
         <Legend />
         {unitNames.map((name, index) => (

--- a/client/src/components/Graphs/LineGraph.jsx
+++ b/client/src/components/Graphs/LineGraph.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend,
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, Label,
 } from 'recharts';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import clsx from 'clsx';
@@ -22,14 +22,23 @@ const LineGraph = ({
   const classes = useStyles();
   const theme = useTheme();
 
+  const xAxisLabel = (value) => (value === 'None' ? '-' : `${value}+`);
+
   return (
     <GraphContainer className={clsx(classes.graph, className)}>
       <LineChart
         data={results}
       >
         <CartesianGrid strokeDasharray="3 3" stroke={theme.palette.graphs.grid} />
-        <XAxis dataKey="save" stroke={theme.palette.graphs.axis} />
-        <YAxis stroke={theme.palette.graphs.axis} />
+        <XAxis dataKey="save" stroke={theme.palette.graphs.axis} tickFormatter={xAxisLabel} />
+        <YAxis stroke={theme.palette.graphs.axis}>
+          <Label
+            value="Average Damage"
+            angle={-90}
+            position="insideLeft"
+            fill={theme.palette.graphs.axis}
+          />
+        </YAxis>
         <Tooltip content={<GraphTooltip />} />
         <Legend />
         {unitNames.map((name, index) => (

--- a/client/src/components/Graphs/RadarGraph.jsx
+++ b/client/src/components/Graphs/RadarGraph.jsx
@@ -30,11 +30,17 @@ const RadarGraph = ({
   const classes = useStyles();
   const theme = useTheme();
 
+  const radarAxisLabel = (value) => (value === 'None' ? '-' : `${value}+`);
+
   return (
     <GraphContainer className={clsx(classes.graph, className)}>
       <RadarChart data={results} outerRadius={120} cy="40%">
         <PolarGrid stroke={theme.palette.graphs.grid} />
-        <PolarAngleAxis dataKey="save" stroke={theme.palette.graphs.axis} />
+        <PolarAngleAxis
+          dataKey="save"
+          stroke={theme.palette.graphs.axis}
+          tickFormatter={radarAxisLabel}
+        />
         <PolarRadiusAxis stroke={theme.palette.graphs.axis} angle={0} />
         <Tooltip content={<GraphTooltip />} />
         <Legend />

--- a/client/src/components/ListControls/ControlHeader.jsx
+++ b/client/src/components/ListControls/ControlHeader.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { IconButton, ButtonGroup, Tooltip } from '@material-ui/core';
-import { Edit, Delete, FileCopy } from '@material-ui/icons';
 import ControlMenu from './ControlMenu';
 
 const HeaderButton = ({
@@ -24,55 +23,34 @@ HeaderButton.propTypes = {
   disabled: PropTypes.bool,
 };
 
-const ControlHeader = ({
-  onEdit, onDelete, onCopy, extraItems, className,
-}) => (
+const ControlHeader = ({ primaryItems, secondaryItems, className }) => (
   <div>
     <ButtonGroup className={`list-controls ${className}`}>
-      {onEdit && (
-      <HeaderButton
-        onClick={typeof onEdit !== 'string' ? onEdit : null}
-        icon={<Edit />}
-        tooltip="Edit"
-      />
-      )}
-      {onCopy && (
-      <HeaderButton
-        onClick={typeof onCopy !== 'string' ? onCopy : null}
-        icon={<FileCopy />}
-        disabled={onCopy === 'disabled'}
-        tooltip="Copy"
-      />
-      )}
-      {onDelete && (
-      <HeaderButton
-        onClick={typeof onDelete !== 'string' ? onDelete : null}
-        icon={<Delete />}
-        tooltip="Delete"
-      />
-      )}
-      {extraItems && <ControlMenu extraItems={extraItems} size="small" />}
+      {primaryItems && primaryItems.map(({
+        name, onClick, disabled, icon,
+      }) => (
+        <HeaderButton
+          onClick={onClick}
+          icon={icon}
+          tooltip={name}
+        />
+      ))}
+      {secondaryItems && <ControlMenu secondaryItems={secondaryItems} size="small" />}
     </ButtonGroup>
   </div>
 );
 
 ControlHeader.defaultProps = {
-  onEdit: null,
-  onDelete: null,
-  onCopy: null,
-  extraItems: null,
+  primaryItems: null,
+  secondaryItems: null,
   className: null,
 };
 
 ControlHeader.propTypes = {
-  /** A function to call when edit button is clicked */
-  onEdit: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when delete button is clicked */
-  onDelete: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when copy button is clicked */
-  onCopy: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /** An array of commands that will be placed in the header */
+  primaryItems: PropTypes.arrayOf(PropTypes.object),
   /** An array of extra commands that will be placed in a control menu */
-  extraItems: PropTypes.arrayOf(PropTypes.object),
+  secondaryItems: PropTypes.arrayOf(PropTypes.object),
   /** CSS classname to give the component */
   className: PropTypes.string,
 };

--- a/client/src/components/ListControls/ControlHeader.jsx
+++ b/client/src/components/ListControls/ControlHeader.jsx
@@ -30,9 +30,11 @@ const ControlHeader = ({ primaryItems, secondaryItems, className }) => (
         name, onClick, disabled, icon,
       }) => (
         <HeaderButton
+          key={name}
           onClick={onClick}
           icon={icon}
           tooltip={name}
+          disabled={disabled}
         />
       ))}
       {secondaryItems && <ControlMenu secondaryItems={secondaryItems} size="small" />}

--- a/client/src/components/ListControls/ControlMenu.jsx
+++ b/client/src/components/ListControls/ControlMenu.jsx
@@ -17,7 +17,7 @@ const useStyles = makeStyles({
  * A menu component with the various options
  */
 const ControlMenu = ({
-  onEdit, onDelete, onCopy, extraItems, size, className,
+  primaryItems, secondaryItems, size, className,
 }) => {
   const classes = useStyles();
   const [anchorEl, setAnchorEl] = useState(null);
@@ -37,7 +37,10 @@ const ControlMenu = ({
     handleClose();
   };
 
-  const hasDivider = (onEdit || onCopy || onDelete) && (extraItems && extraItems.length);
+  const hasDivider = (
+    (primaryItems && primaryItems.length)
+    && (secondaryItems && secondaryItems.length)
+  );
 
   return (
     <div className={clsx(classes.menu, className)}>
@@ -51,11 +54,13 @@ const ControlMenu = ({
         open={Boolean(anchorEl)}
         onClose={handleClose}
       >
-        {onEdit && <MenuItem onClick={() => menuItemClick(onEdit)}>Edit</MenuItem>}
-        {onCopy && <MenuItem onClick={() => menuItemClick(onCopy)} disabled={onCopy === 'disabled'}>Copy</MenuItem>}
-        {onDelete && <MenuItem onClick={() => menuItemClick(onDelete)}>Delete</MenuItem>}
+        {primaryItems && primaryItems.map(({ name, onClick, disabled }) => (
+          <MenuItem onClick={() => menuItemClick(onClick)} key={name} disabled={disabled}>
+            {name}
+          </MenuItem>
+        ))}
         {hasDivider && <Divider />}
-        {extraItems && extraItems.map(({ name, onClick, disabled }) => (
+        {secondaryItems && secondaryItems.map(({ name, onClick, disabled }) => (
           <MenuItem onClick={() => menuItemClick(onClick)} key={name} disabled={disabled}>
             {name}
           </MenuItem>
@@ -66,23 +71,17 @@ const ControlMenu = ({
 };
 
 ControlMenu.defaultProps = {
-  onEdit: null,
-  onDelete: null,
-  onCopy: null,
-  extraItems: null,
+  primaryItems: null,
+  secondaryItems: null,
   className: null,
   size: 'medium',
 };
 
 ControlMenu.propTypes = {
-  /** A function to call when edit button is clicked */
-  onEdit: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when delete button is clicked */
-  onDelete: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when copy button is clicked */
-  onCopy: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** An array of extra commands that will be placed in the control menu */
-  extraItems: PropTypes.arrayOf(PropTypes.object),
+  /** An array of primary commands that will be placed in the first section of the control menu */
+  primaryItems: PropTypes.arrayOf(PropTypes.object),
+  /** An array of extra commands that will be placed in the second section of the control menu */
+  secondaryItems: PropTypes.arrayOf(PropTypes.object),
   /** CSS classname to give the component */
   className: PropTypes.string,
   /** The size of the menu component */

--- a/client/src/components/ListControls/ListControls.jsx
+++ b/client/src/components/ListControls/ListControls.jsx
@@ -10,51 +10,43 @@ import ControlHeader from './ControlHeader';
  * A list of buttons to display for the list item
  * */
 const ListControls = ({
-  onEdit, onDelete, onCopy, extraItems, className,
+  primaryItems, secondaryItems, className,
 }) => {
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
 
-  if (!onEdit && !onCopy && !onDelete && !extraItems) return null;
+  if (!primaryItems && !secondaryItems) return null;
   return mobile
     ? (
       <ControlMenu
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onCopy={onCopy}
-        extraItems={extraItems}
+        primaryItems={primaryItems}
+        secondaryItems={secondaryItems}
         className={className}
       />
     )
     : (
       <ControlHeader
         className={className}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onCopy={onCopy}
-        extraItems={extraItems}
+        primaryItems={primaryItems}
+        secondaryItems={secondaryItems}
       />
     );
 };
 
 ListControls.defaultProps = {
-  onEdit: null,
-  onDelete: null,
-  onCopy: null,
-  extraItems: null,
+  primaryItems: null,
+  secondaryItems: null,
   className: null,
 };
 
 
 ListControls.propTypes = {
-  /** A function to call when edit button is clicked */
-  onEdit: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when delete button is clicked */
-  onDelete: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when copy button is clicked */
-  onCopy: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** An array of extra commands that will be placed in a control menu */
-  extraItems: PropTypes.arrayOf(PropTypes.object),
+  /** An array of (primary) commands that will be placed in the header for desktop, and in
+   * the first portion of the menu for mobile
+   * */
+  primaryItems: PropTypes.arrayOf(PropTypes.object),
+  /** An array of extra (secondary) commands that will be placed in a control menu */
+  secondaryItems: PropTypes.arrayOf(PropTypes.object),
   /** CSS classname to give the component */
   className: PropTypes.string,
 };

--- a/client/src/components/ListControls/stories/ListControls.story.js
+++ b/client/src/components/ListControls/stories/ListControls.story.js
@@ -17,7 +17,7 @@ storiesOf('Components/ListControls', module)
       onEdit={boolean('Edit Enabled', true) ? () => {} : null}
       onCopy={boolean('Copy Enabled', true) ? () => {} : null}
       onDelete={boolean('Delete Enabled', true) ? () => {} : null}
-      extraItems={[
+      secondaryItems={[
         { name: 'Import', onClick: () => {} },
         { name: 'Export', onClick: () => {} },
       ]}

--- a/client/src/components/ListItem/ListItem.jsx
+++ b/client/src/components/ListItem/ListItem.jsx
@@ -29,7 +29,7 @@ const useStyles = makeStyles(() => ({
  * contain various list related controls, as well as, optionally be collapsible.
  */
 const ListItem = ({
-  children, header, onEdit, onDelete, onCopy, extraItems, className, collapsible,
+  children, header, primaryItems, secondaryItems, className, collapsible,
   loading, loaderDelay, ...other
 }) => {
   const classes = useStyles();
@@ -39,10 +39,8 @@ const ListItem = ({
     <Card className={clsx(classes.listItem, className)} {...other}>
       <ListItemHeader
         header={header}
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onCopy={onCopy}
-        extraItems={extraItems}
+        primaryItems={primaryItems}
+        secondaryItems={secondaryItems}
         collapsible={collapsible}
         collapsed={collapsed}
         setColapsed={setColapsed}
@@ -58,10 +56,8 @@ const ListItem = ({
 };
 
 ListItem.defaultProps = {
-  onEdit: null,
-  onDelete: null,
-  onCopy: null,
-  extraItems: null,
+  primaryItems: null,
+  secondaryItems: null,
   className: null,
   collapsible: false,
   loading: false,
@@ -73,14 +69,12 @@ ListItem.propTypes = {
   header: PropTypes.string.isRequired,
   /** The react components to render in the card body */
   children: PropTypes.node.isRequired,
-  /** A function to call when edit button is clicked */
-  onEdit: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when delete button is clicked */
-  onDelete: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when copy button is clicked */
-  onCopy: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /** An array of (primary) commands that will be placed in the header for desktop, and in
+   * the first portion of the menu for mobile
+   * */
+  primaryItems: PropTypes.arrayOf(PropTypes.object),
   /** An array of extra commands that will be placed in the control menu */
-  extraItems: PropTypes.arrayOf(PropTypes.object),
+  secondaryItems: PropTypes.arrayOf(PropTypes.object),
   /** CSS classname to give the component */
   className: PropTypes.string,
   /** Whether the list item is collapsible or not */

--- a/client/src/components/ListItem/ListItemHeader.jsx
+++ b/client/src/components/ListItem/ListItemHeader.jsx
@@ -43,7 +43,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const ListItemHeader = ({
-  header, onEdit, onDelete, onCopy, extraItems, className, collapsible, collapsed, setColapsed,
+  header, primaryItems, secondaryItems, className, collapsible, collapsed, setColapsed,
 }) => {
   const classes = useStyles();
   const theme = useTheme();
@@ -54,14 +54,13 @@ const ListItemHeader = ({
 
   const handleClick = () => setColapsed((!collapsible) ? false : !collapsed);
 
-  const dialogActions = [];
-  if (onDelete) dialogActions.push({ label: 'Delete', onClick: onDelete });
-  if (onCopy) {
-    dialogActions.push({
-      label: 'Copy',
-      onClick: onCopy,
-      disabled: (!onCopy || onCopy === 'disabled'),
-    });
+  let dialogActions = [];
+  if (primaryItems && primaryItems.length) {
+    dialogActions = primaryItems.map(({ name, onClick, disabled }) => ({
+      label: name,
+      onClick,
+      disabled,
+    }));
   }
 
   return (
@@ -96,10 +95,8 @@ const ListItemHeader = ({
         />
       )}
       <ListControls
-        onEdit={onEdit}
-        onDelete={onDelete}
-        onCopy={onCopy}
-        extraItems={extraItems}
+        primaryItems={primaryItems}
+        secondaryItems={secondaryItems}
         className={classes.listControls}
       />
     </Card.Header>
@@ -108,10 +105,8 @@ const ListItemHeader = ({
 
 ListItemHeader.defaultProps = {
   children: null,
-  onEdit: null,
-  onDelete: null,
-  onCopy: null,
-  extraItems: null,
+  primaryItems: null,
+  secondaryItems: null,
   className: null,
   collapsible: false,
   collapsed: false,
@@ -123,14 +118,12 @@ ListItemHeader.propTypes = {
   header: PropTypes.string.isRequired,
   /** The react components to render in the card body */
   children: PropTypes.node,
-  /** A function to call when edit button is clicked */
-  onEdit: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when delete button is clicked */
-  onDelete: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
-  /** A function to call when copy button is clicked */
-  onCopy: PropTypes.oneOfType([PropTypes.func, PropTypes.string]),
+  /** An array of (primary) commands that will be placed in the header for desktop, and in
+   * the first portion of the menu for mobile
+   * */
+  primaryItems: PropTypes.arrayOf(PropTypes.object),
   /** An array of extra commands that will be placed in the control menu */
-  extraItems: PropTypes.arrayOf(PropTypes.object),
+  secondaryItems: PropTypes.arrayOf(PropTypes.object),
   /** CSS classname to give the component */
   className: PropTypes.string,
   /** Whether the list item is collapsible or not */

--- a/client/src/components/ModifierItem/ModifierDescription.jsx
+++ b/client/src/components/ModifierItem/ModifierDescription.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
 import clsx from 'clsx';
+import _ from 'lodash';
 
 const formatUnicorn = require('format-unicorn/safe');
 
@@ -17,7 +18,7 @@ const useStyles = makeStyles({
  * A component used to render the modifier description. It will use the definition description
  * as a base and substitute the current values into it
  * */
-const ModifierDescription = ({ definition, options, className }) => {
+const ModifierDescription = React.memo(({ definition, options, className }) => {
   const classes = useStyles();
 
   const { description } = definition;
@@ -45,7 +46,7 @@ const ModifierDescription = ({ definition, options, className }) => {
       <span dangerouslySetInnerHTML={{ __html: getFormattedDescription() }} />
     </Typography>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 ModifierDescription.defaultProps = {
   className: null,

--- a/client/src/components/ModifierItem/ModifierInput.jsx
+++ b/client/src/components/ModifierItem/ModifierInput.jsx
@@ -7,16 +7,14 @@ import { makeStyles } from '@material-ui/core/styles';
 import RollInput from 'components/RollInput';
 import DiceInput from 'components/DiceInput';
 
-const useStyles = makeStyles({
+const useStyles = makeStyles(() => ({
   modifierInput: {
     marginRight: '1em',
     margin: '.5em 0',
     width: '100%',
   },
-  choice: {
-
-  },
-});
+  choice: {},
+}));
 
 const ModifierInput = ({
   index, name, option, val, onOptionChange, errorCallback,
@@ -59,7 +57,7 @@ const ModifierInput = ({
           name={name}
           className={classes.modifierInput}
           fullWidth
-          variant="filled"
+          variant="outlined"
           value={val}
           {...errorProps}
           onChange={handleChange}
@@ -81,6 +79,7 @@ const ModifierInput = ({
               checked={val}
               {...errorProps}
               onChange={handleChecked}
+              color="primary"
             />
           )}
           label={name}
@@ -98,6 +97,7 @@ const ModifierInput = ({
           onChange={(event) => onOptionChange(index, name, event.target.value)}
           allowOnes={option.allowOnes}
           errorCallback={childErrorCallback}
+          variant="outlined"
           required
         />
       );
@@ -113,6 +113,7 @@ const ModifierInput = ({
             value={val}
             onChange={(event) => onOptionChange(index, name, event.target.value)}
             errorCallback={childErrorCallback}
+            variant="outlined"
             required
           />
         )
@@ -123,7 +124,7 @@ const ModifierInput = ({
             className={classes.modifierInput}
             fullWidth
             type="number"
-            variant="filled"
+            variant="outlined"
             value={val}
             {...errorProps}
             onChange={handleChange}
@@ -143,14 +144,14 @@ ModifierInput.propTypes = {
   name: PropTypes.string.isRequired,
   /** The option properties for the modifier definition */
   option: PropTypes.shape({
-    type: PropTypes.string.isRequired,
-    items: PropTypes.arrayOf([PropTypes.string]),
-    default: PropTypes.string,
+    type: PropTypes.string,
+    items: PropTypes.arrayOf(PropTypes.string),
+    default: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     allowOnes: PropTypes.bool,
     allowDice: PropTypes.bool,
   }).isRequired,
   /** The current value of the option */
-  val: PropTypes.string.isRequired,
+  val: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
   /** A callback function to call when any of the option values are changed */
   onOptionChange: PropTypes.func.isRequired,
   /** An optional callback function used to pass back the error state of the modifier item */

--- a/client/src/components/ModifierItem/ModifierInput.jsx
+++ b/client/src/components/ModifierItem/ModifierInput.jsx
@@ -5,6 +5,7 @@ import {
 } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import RollInput from 'components/RollInput';
+import _ from 'lodash';
 import DiceInput from 'components/DiceInput';
 
 const useStyles = makeStyles(() => ({
@@ -16,7 +17,7 @@ const useStyles = makeStyles(() => ({
   choice: {},
 }));
 
-const ModifierInput = ({
+const ModifierInput = React.memo(({
   index, name, option, val, onOptionChange, errorCallback,
 }) => {
   const classes = useStyles();
@@ -131,7 +132,7 @@ const ModifierInput = ({
           />
         );
   }
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 ModifierInput.defaultProps = {
   errorCallback: null,

--- a/client/src/components/ModifierItem/ModifierItem.jsx
+++ b/client/src/components/ModifierItem/ModifierItem.jsx
@@ -35,7 +35,7 @@ const useStyles = makeStyles((theme) => ({
 /**
  * A component representing a single modifier in the Profile Dialog
  */
-const ModifierItem = ({
+const ModifierItem = React.memo(({
   index, id, options, actions, onOptionChange, errorCallback,
 }) => {
   const classes = useStyles();
@@ -90,7 +90,7 @@ const ModifierItem = ({
       </ListItem>
     </div>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 ModifierItem.defaultProps = {
   actions: null,

--- a/client/src/components/ModifierItem/ModifierItem.jsx
+++ b/client/src/components/ModifierItem/ModifierItem.jsx
@@ -6,6 +6,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import ListItem from 'components/ListItem';
 import _ from 'lodash';
 import { getModifierById } from 'utils/modifierHelpers';
+import { Delete } from '@material-ui/icons';
 import ModifierInput from './ModifierInput';
 import ModifierDescription from './ModifierDescription';
 import { errorReducer } from './reducers';
@@ -64,6 +65,9 @@ const ModifierItem = ({
       <ListItem
         className={classes.modifier}
         onDelete={() => removeModifier(index)}
+        primaryItems={[
+          { name: 'Delete', onClick: () => removeModifier(index), icon: <Delete /> },
+        ]}
         header={definition.name}
         collapsible
       >

--- a/client/src/components/ModifierItem/ModifierItem.jsx
+++ b/client/src/components/ModifierItem/ModifierItem.jsx
@@ -11,7 +11,9 @@ import ModifierDescription from './ModifierDescription';
 import { errorReducer } from './reducers';
 
 const useStyles = makeStyles((theme) => ({
-  modifier: {},
+  modifier: {
+    background: theme.palette.background.nested,
+  },
   modifierContent: {
     display: 'flex',
     flex: 1,

--- a/client/src/components/ModifierItem/ModifierItem.jsx
+++ b/client/src/components/ModifierItem/ModifierItem.jsx
@@ -6,7 +6,6 @@ import { makeStyles } from '@material-ui/core/styles';
 import ListItem from 'components/ListItem';
 import _ from 'lodash';
 import { getModifierById } from 'utils/modifierHelpers';
-import { Delete } from '@material-ui/icons';
 import ModifierInput from './ModifierInput';
 import ModifierDescription from './ModifierDescription';
 import { errorReducer } from './reducers';
@@ -37,7 +36,7 @@ const useStyles = makeStyles((theme) => ({
  * A component representing a single modifier in the Profile Dialog
  */
 const ModifierItem = ({
-  index, id, options, removeModifier, onOptionChange, errorCallback,
+  index, id, options, actions, onOptionChange, errorCallback,
 }) => {
   const classes = useStyles();
   const itemRef = useRef(null);
@@ -64,10 +63,7 @@ const ModifierItem = ({
     <div ref={itemRef}>
       <ListItem
         className={classes.modifier}
-        onDelete={() => removeModifier(index)}
-        primaryItems={[
-          { name: 'Delete', onClick: () => removeModifier(index), icon: <Delete /> },
-        ]}
+        primaryItems={actions}
         header={definition.name}
         collapsible
       >
@@ -97,6 +93,7 @@ const ModifierItem = ({
 };
 
 ModifierItem.defaultProps = {
+  actions: null,
   errorCallback: null,
 };
 
@@ -107,8 +104,8 @@ ModifierItem.propTypes = {
   id: PropTypes.string.isRequired,
   /** An object containing all of the option values */
   options: PropTypes.shape({ value: PropTypes.any }).isRequired,
-  /** A callback function used to remove the modifier from the list */
-  removeModifier: PropTypes.func.isRequired,
+  /** A list of actions that can be performed on the item (displayed in the header) */
+  actions: PropTypes.arrayOf(PropTypes.object),
   /** A callback function to call when any of the option values are changed */
   onOptionChange: PropTypes.func.isRequired,
   /** An optional callback function used to pass back the error state of the modifier item */

--- a/client/src/components/ModifierItem/ModifierItem.jsx
+++ b/client/src/components/ModifierItem/ModifierItem.jsx
@@ -72,12 +72,12 @@ const ModifierItem = ({
           {definition.options && Object.keys(definition.options).length
             ? (
               <div className={classes.modifierSettings}>
-                {Object.keys(options).map((n) => (
+                {Object.keys(definition.options).map((n) => (
                   <ModifierInput
                     index={index}
                     name={n}
                     option={definition.options[n]}
-                    val={options[n]}
+                    val={options[n] != null ? options[n] : ''}
                     onOptionChange={onOptionChange}
                     key={n}
                     errorCallback={getErrorCallback(n)}

--- a/client/src/components/ModifierList/ModifierList.jsx
+++ b/client/src/components/ModifierList/ModifierList.jsx
@@ -5,10 +5,12 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { makeStyles } from '@material-ui/core/styles';
 import { Typography } from '@material-ui/core';
+import { Delete, ArrowUpward, ArrowDownward } from '@material-ui/icons';
 import ModifierSelector from 'components/ModifierSelector';
 import ModifierItem from 'components/ModifierItem';
 import { MAX_MODIFIERS } from 'appConstants';
 import _ from 'lodash';
+import { moveItemInArray } from 'reducers/helpers';
 import PendingModifiers from './PendingModifiers';
 import { errorReducer } from './reducers';
 
@@ -55,6 +57,12 @@ const ModifierList = ({
     dispatchErrors({ type: 'REMOVE_ERROR', index });
   };
 
+  const moveModifier = (index, newIndex) => {
+    moveItemInArray(modifiers, index, newIndex, (newState) => {
+      setModifiers(newState);
+    });
+  };
+
   const onOptionChange = (index, name, value) => {
     if (!modifiers) return;
     setModifiers(modifiers.map((modifier, i) => {
@@ -75,6 +83,9 @@ const ModifierList = ({
     dispatchErrors({ type: 'SET_ERROR', index, error });
   }), []);
 
+  const moveUpEnabled = (index) => index > 0;
+  const moveDownEnabled = (index) => index < (modifiers || []).length - 1;
+
   return (
     <Typography component="div" className={classes.modifierList}>
       <label>Modifiers:</label>
@@ -85,7 +96,21 @@ const ModifierList = ({
             {(modifiers || []).map((modifier, index) => (
               <ModifierItem
                 {...modifier}
-                removeModifier={removeModifier}
+                actions={[
+                  {
+                    name: 'Move Up',
+                    onClick: () => moveModifier(index, index - 1),
+                    icon: <ArrowUpward />,
+                    disabled: !moveUpEnabled(index),
+                  },
+                  {
+                    name: 'Move Down',
+                    onClick: () => moveModifier(index, index + 1),
+                    icon: <ArrowDownward />,
+                    disabled: !moveDownEnabled(index),
+                  },
+                  { name: 'Delete', onClick: () => removeModifier(index), icon: <Delete /> },
+                ]}
                 index={index}
                 // eslint-disable-next-line react/no-array-index-key
                 key={index}
@@ -104,6 +129,7 @@ const ModifierList = ({
 };
 
 ModifierList.defaultProps = {
+  modifiers: [],
   errorCallback: null,
 };
 
@@ -117,7 +143,7 @@ ModifierList.propTypes = {
   modifiers: PropTypes.arrayOf(PropTypes.shape({
     id: PropTypes.isRequired,
     options: PropTypes.object.isRequired,
-  })).isRequired,
+  })),
   /** A callback function to call when the modifiers list is changed */
   setModifiers: PropTypes.func.isRequired,
   /** A callback function to pass back the error state of the list of modifiers */

--- a/client/src/components/ModifierSelector/ModifierOption.jsx
+++ b/client/src/components/ModifierSelector/ModifierOption.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { Add } from '@material-ui/icons';
 import { ListItem, Typography } from '@material-ui/core';
+import _ from 'lodash';
 
 
 const useStyles = makeStyles((theme) => ({
@@ -30,7 +31,7 @@ const useStyles = makeStyles((theme) => ({
 /**
  * A single modifier definition
  */
-const ModifierOption = ({ modifier, onClick }) => {
+const ModifierOption = React.memo(({ modifier, onClick }) => {
   const classes = useStyles();
   return (
     <ListItem className={classes.modifierOption} onClick={() => onClick(modifier)} button>
@@ -49,7 +50,7 @@ const ModifierOption = ({ modifier, onClick }) => {
       </div>
     </ListItem>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 ModifierOption.propTypes = {
   /** The modifier definition object */

--- a/client/src/components/ModifierSelector/ModifierSelector.jsx
+++ b/client/src/components/ModifierSelector/ModifierSelector.jsx
@@ -7,6 +7,7 @@ import {
 import { Add, Remove, Sync } from '@material-ui/icons';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import { useHistory, useLocation, Route } from 'react-router-dom';
+import _ from 'lodash';
 import ModifierOption from './ModifierOption';
 import SelectorDialog from './SelectorDialog';
 
@@ -19,7 +20,7 @@ const useStyles = makeStyles(() => ({
 /**
  * A component used to select new modifiers to apply
  */
-const ModifierSelector = ({
+const ModifierSelector = React.memo(({
   modifiers, pending, error, onClick, disabled,
 }) => {
   const classes = useStyles();
@@ -120,7 +121,7 @@ const ModifierSelector = ({
         )}
     </div>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 ModifierSelector.defaultProps = {
   error: null,

--- a/client/src/components/NoItemsCard/NoItemsCard.jsx
+++ b/client/src/components/NoItemsCard/NoItemsCard.jsx
@@ -24,16 +24,24 @@ const useStyles = makeStyles((theme) => ({
     height: 'auto',
     maxWidth: '3rem',
   },
+  nested: {
+    backgroundColor: theme.palette.background.nested,
+  },
 }));
 
 /**
  * A card used to represent the lack of items in a list
  */
-const NoItemsCard = ({ header, body, dense }) => {
+const NoItemsCard = ({
+  header, body, dense, nested,
+}) => {
   const classes = useStyles();
 
   return (
-    <Paper className={clsx(classes.noItemsContainer, dense ? classes.dense : '')}>
+    <Paper className={clsx(
+      classes.noItemsContainer, dense && classes.dense, nested && classes.nested,
+    )}
+    >
       <InfoOutlined className={classes.icon} />
       <div className={classes.content}>
         <Typography variant={dense ? 'h6' : 'h5'} component="h3">
@@ -49,6 +57,7 @@ const NoItemsCard = ({ header, body, dense }) => {
 
 NoItemsCard.defaultProps = {
   dense: false,
+  nested: false,
 };
 
 NoItemsCard.propTypes = {
@@ -58,6 +67,8 @@ NoItemsCard.propTypes = {
   body: PropTypes.string.isRequired,
   /** Whether the card should be densly packed */
   dense: PropTypes.bool,
+  /** Whether the card should represent a nested card */
+  nested: PropTypes.bool,
 };
 
 export default NoItemsCard;

--- a/client/src/components/RollInput/RollInput.jsx
+++ b/client/src/components/RollInput/RollInput.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { TextField, InputAdornment } from '@material-ui/core';
 import clsx from 'clsx';
+import _ from 'lodash';
 
 const useStyles = makeStyles({
   rollInput: {},
 });
 
-const RollInput = ({
+const RollInput = React.memo(({
   label, value, onChange, className, required, allowOnes,
   startAdornment, endAdornment, errorCallback, ...other
 }) => {
@@ -75,7 +76,7 @@ const RollInput = ({
       {...other}
     />
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 RollInput.defaultProps = {
   label: null,

--- a/client/src/components/StatsErrorCard/StatsErrorCard.jsx
+++ b/client/src/components/StatsErrorCard/StatsErrorCard.jsx
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { makeStyles } from '@material-ui/core/styles';
 import { Paper, Typography } from '@material-ui/core';
+import { lighten } from '@material-ui/core/styles/colorManipulator';
 import clsx from 'clsx';
 import { fetchStatsCompare } from 'api';
 import { bindActionCreators } from 'redux';
@@ -15,8 +16,9 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    backgroundColor: red[100],
-    color: theme.palette.getContrastText(red[100]),
+    // backgroundColor: red[100],
+    backgroundColor: theme.palette.background.error,
+    color: theme.palette.getContrastText(theme.palette.background.error),
     width: '100%',
     height: '100%',
     padding: theme.spacing(2),
@@ -26,7 +28,8 @@ const useStyles = makeStyles((theme) => ({
       duration: theme.transitions.duration.short,
     }),
     '&:hover': {
-      backgroundColor: red[200],
+      // backgroundColor: red[200],
+      backgroundColor: lighten(theme.palette.background.error, 0.3),
     },
     '&:focus, &:active': {
       backgroundColor: red[300],

--- a/client/src/components/StoreSubscriber/StatsSubscriber.jsx
+++ b/client/src/components/StoreSubscriber/StatsSubscriber.jsx
@@ -6,6 +6,7 @@ import { bindActionCreators } from 'redux';
 import { useDebouncedCallback } from 'use-debounce';
 import { DEBOUNCE_TIMEOUT } from 'appConstants';
 import { usePrevious } from 'hooks';
+import _ from 'lodash';
 
 /**
  * Filter out the name from a unit as there is not need to refetch the stats
@@ -27,7 +28,7 @@ const StatsSubscriber = ({ units, fetchStatsCompare }) => {
     let prevUnits = (prevState && prevState.units) ? prevState.units : [];
     prevUnits = prevUnits.map((u) => filterNameFromUnit(u));
     const newUnits = units.map((u) => filterNameFromUnit(u));
-    if (JSON.stringify(prevUnits) !== JSON.stringify(newUnits)) {
+    if (!_.isEqual(prevUnits, newUnits)) {
       fetchStatsCompare();
     }
   };

--- a/client/src/containers/App/App.jsx
+++ b/client/src/containers/App/App.jsx
@@ -19,6 +19,7 @@ const App = ({ config }) => (
       <CssBaseline />
       <Switch>
         <Route exact path="/" component={AppContentWrapper} />
+        <Redirect exact from="/units" to="/" />
         <Route path="/units" component={AppContentWrapper} />
         <Redirect to="/" />
       </Switch>

--- a/client/src/containers/ProfileDialog/DialogContent.jsx
+++ b/client/src/containers/ProfileDialog/DialogContent.jsx
@@ -55,7 +55,6 @@ const DialogContent = ({
   const classes = useStyles();
 
   const getErrorCallback = useCallback(_.memoize((name) => (error) => {
-    // console.log(name, error);
     errorCallback(name, error);
   }), []);
 

--- a/client/src/containers/ProfileDialog/DialogContent.jsx
+++ b/client/src/containers/ProfileDialog/DialogContent.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import PropTypes from 'prop-types';
 import {
   Typography, DialogContent as Content,
 } from '@material-ui/core';
@@ -136,5 +137,26 @@ const DialogContent = React.memo(({
     </Content>
   );
 }, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
+
+DialogContent.defaultProps = {
+  submitDisabled: false,
+};
+
+DialogContent.propTypes = {
+  profile: PropTypes.shape({
+    num_models: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    attacks: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    to_hit: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    to_wound: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    rend: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    damage: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    modifiers: PropTypes.arrayOf(PropTypes.object),
+  }).isRequired,
+  onChange: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  errorCallback: PropTypes.func.isRequired,
+  submitDisabled: PropTypes.bool,
+  dispatchState: PropTypes.func.isRequired,
+};
 
 export default DialogContent;

--- a/client/src/containers/ProfileDialog/DialogContent.jsx
+++ b/client/src/containers/ProfileDialog/DialogContent.jsx
@@ -49,14 +49,20 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const DialogContent = ({
-  profile, onChange, onSubmit, errorCallback, submitDisabled,
+const DialogContent = React.memo(({
+  profile, onChange, onSubmit, errorCallback, submitDisabled, dispatchState,
 }) => {
   const classes = useStyles();
 
   const getErrorCallback = useCallback(_.memoize((name) => (error) => {
     errorCallback(name, error);
   }), []);
+
+  const getHandler = useCallback(_.memoize((name) => (event) => {
+    onChange(name, event.target.value);
+  }), []);
+
+  const handleModifiersChange = (val) => onChange('modifiers', val);
 
   return (
     <Content dividers>
@@ -70,7 +76,7 @@ const DialogContent = ({
                 className={classes.field}
                 label="# Models"
                 value={profile.num_models}
-                onChange={(val) => onChange('num_models', val)}
+                onChange={getHandler('num_models')}
                 errorCallback={getErrorCallback('num_models')}
                 type="number"
               />
@@ -78,7 +84,7 @@ const DialogContent = ({
                 className={classes.field}
                 label="Attacks"
                 value={profile.attacks}
-                onChange={(e) => onChange('attacks', e.target.value)}
+                onChange={getHandler('attacks')}
                 errorCallback={getErrorCallback('attacks')}
                 required
               />
@@ -87,7 +93,7 @@ const DialogContent = ({
                 endAdornment="+"
                 label="To Hit"
                 value={profile.to_hit}
-                onChange={(e) => onChange('to_hit', e.target.value)}
+                onChange={getHandler('to_hit')}
                 errorCallback={getErrorCallback('to_hit')}
               />
               <RollInput
@@ -95,7 +101,7 @@ const DialogContent = ({
                 endAdornment="+"
                 label="To Wound"
                 value={profile.to_wound}
-                onChange={(e) => onChange('to_wound', e.target.value)}
+                onChange={getHandler('to_wound')}
                 errorCallback={getErrorCallback('to_wound')}
               />
               <FormField
@@ -103,14 +109,14 @@ const DialogContent = ({
                 startAdornment="-"
                 label="Rend"
                 value={profile.rend}
-                onChange={(val) => onChange('rend', val)}
+                onChange={getHandler('rend')}
                 errorCallback={getErrorCallback('to_wound')}
               />
               <DiceInput
                 className={classes.field}
                 label="Damage"
                 value={profile.damage}
-                onChange={(e) => onChange('damage', e.target.value)}
+                onChange={getHandler('damage')}
                 errorCallback={getErrorCallback('damage')}
                 required
               />
@@ -119,7 +125,8 @@ const DialogContent = ({
           <div className={clsx(classes.formSection, classes.modifiers)}>
             <ModifierList
               modifiers={profile.modifiers}
-              setModifiers={(val) => onChange('modifiers', val)}
+              setModifiers={handleModifiersChange}
+              dispatchModifiers={dispatchState}
               tabIndex={-1}
               errorCallback={getErrorCallback('modifiers')}
             />
@@ -128,7 +135,6 @@ const DialogContent = ({
       </Typography>
     </Content>
   );
-};
-
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 export default DialogContent;

--- a/client/src/containers/ProfileDialog/DialogTitle.jsx
+++ b/client/src/containers/ProfileDialog/DialogTitle.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import {
   Typography, DialogTitle as Title, AppBar, Toolbar, IconButton,
 } from '@material-ui/core';
@@ -29,6 +30,16 @@ const DialogTitle = ({ header, fullScreen, onClose }) => {
       )
       : <Title>{header}</Title>
   );
+};
+
+DialogTitle.defaultProps = {
+  fullScreen: false,
+};
+
+DialogTitle.propTypes = {
+  header: PropTypes.string.isRequired,
+  fullScreen: PropTypes.bool,
+  onClose: PropTypes.func.isRequired,
 };
 
 export default DialogTitle;

--- a/client/src/containers/ProfileDialog/FormField.jsx
+++ b/client/src/containers/ProfileDialog/FormField.jsx
@@ -3,14 +3,14 @@ import PropTypes from 'prop-types';
 import { TextField, InputAdornment } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
+import _ from 'lodash';
 
 
 const useStyles = makeStyles(() => ({
   field: {},
 }));
 
-
-const FormField = ({
+const FormField = React.memo(({
   label, value, onChange, className, startAdornment, endAdornment, type, errorCallback,
 }) => {
   const classes = useStyles();
@@ -33,7 +33,7 @@ const FormField = ({
   const handleChange = useCallback((event) => {
     const val = event.target.value;
     setError(val == null || val === '');
-    onChange(val);
+    onChange(event);
   }, [onChange]);
 
   return (
@@ -50,7 +50,7 @@ const FormField = ({
     />
 
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 FormField.defaultProps = {
   type: 'number',

--- a/client/src/containers/ProfileDialog/ProfileDialog.jsx
+++ b/client/src/containers/ProfileDialog/ProfileDialog.jsx
@@ -110,6 +110,7 @@ const ProfileDialog = ({ editWeaponProfile, open }) => {
         onSubmit={submit}
         errorCallback={setErrorByName}
         submitDisabled={submitDisabled}
+        dispatchState={dispatchState}
       />
       <DialogActions className={classes.actions}>
         <Button

--- a/client/src/containers/ProfileDialog/reducers.js
+++ b/client/src/containers/ProfileDialog/reducers.js
@@ -1,3 +1,6 @@
+import { moveItemInArray, updateItemInArray } from 'reducers/helpers';
+import nanoid from 'nanoid';
+
 export const errorReducer = (state, action) => {
   switch (action.type) {
     case 'SET_ERROR':
@@ -5,6 +8,46 @@ export const errorReducer = (state, action) => {
         ...state,
         [action.name]: action.error,
       };
+    default:
+      return state;
+  }
+};
+
+const modifiersReducer = (state, action) => {
+  switch (action.type) {
+    case 'INIT_PROFILE':
+      if (action.modifiers && action.modifiers.length) {
+        return action.modifiers.map((mod) => ({
+          ...mod,
+          uuid: mod.uuid || nanoid(),
+        }));
+      }
+      return [];
+    case 'ADD_MODIFIER':
+      if (state && state.length) {
+        return [
+          ...state,
+          { ...action.modifier, uuid: nanoid() },
+        ];
+      }
+      return [{ ...action.modifier, uuid: nanoid() }];
+    case 'REMOVE_MODIFIER':
+      return state.filter((_, index) => index !== action.index);
+    case 'MOVE_MODIFIER':
+      return moveItemInArray(state, action.index, action.newIndex, (state) => state);
+    case 'EDIT_MODIFIER':
+      return updateItemInArray(state, action.index, (item) => ({
+        ...item,
+        ...action.item,
+      }));
+    case 'EDIT_MODIFIER_OPTION':
+      return updateItemInArray(state, action.index, (item) => ({
+        ...item,
+        options: {
+          ...item.options,
+          [action.name]: action.value,
+        },
+      }));
     default:
       return state;
   }
@@ -20,12 +63,21 @@ export const profileReducer = (state, action) => {
         to_wound: action.profile.to_wound,
         rend: action.profile.rend,
         damage: action.profile.damage,
-        modifiers: action.profile.modifiers,
+        modifiers: modifiersReducer([], { type: action.type, ...action.profile }),
       };
     case 'SET_PROFILE':
       return {
         ...state,
         [action.name]: action.val,
+      };
+    case 'ADD_MODIFIER':
+    case 'REMOVE_MODIFIER':
+    case 'MOVE_MODIFIER':
+    case 'EDIT_MODIFIER':
+    case 'EDIT_MODIFIER_OPTION':
+      return {
+        ...state,
+        modifiers: modifiersReducer(state.modifiers, action),
       };
     default:
       return state;

--- a/client/src/containers/Stats/Graphs.jsx
+++ b/client/src/containers/Stats/Graphs.jsx
@@ -32,13 +32,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const graphColors = [
-  '#8884d8',
-  '#82ca9d',
-  '#ff7300',
-  '#413ea0',
-  '#f50057',
-];
+const graphNames = ['Bar Graph', 'Line Graph', 'Radar Graph'];
+const graphList = [BarGraph, LineGraph, RadarGraph];
 
 const GraphWrapper = ({
   loading, error, children, numUnits,
@@ -57,7 +52,6 @@ const GraphWrapper = ({
 
 const GraphTabbed = ({ stats, unitNames, graphList }) => {
   const classes = useStyles();
-  const tabNames = ['Line Graph', 'Bar Graph', 'Radar Graph'];
   const firstLoad = (!stats.payload || !stats.payload.length) && stats.pending;
 
   return (
@@ -70,12 +64,12 @@ const GraphTabbed = ({ stats, unitNames, graphList }) => {
     >
       <Tabbed
         className={classes.tabs}
-        tabNames={tabNames}
+        tabNames={graphNames}
         tabContent={graphList.map((Graph, index) => (
           <GraphWrapper
             loading={firstLoad}
             numUnits={unitNames.length}
-            key={tabNames[index]}
+            key={graphNames[index]}
             error={Boolean(stats.error)}
           >
             <Paper square className={classes.tab}>
@@ -83,7 +77,6 @@ const GraphTabbed = ({ stats, unitNames, graphList }) => {
                 className={classes.content}
                 results={stats.payload}
                 unitNames={unitNames}
-                colors={graphColors}
               />
             </Paper>
           </GraphWrapper>
@@ -95,15 +88,14 @@ const GraphTabbed = ({ stats, unitNames, graphList }) => {
 
 const GraphList = ({ stats, unitNames, graphList }) => {
   const classes = useStyles();
-  const names = ['Line Graph', 'Bar Graph', 'Radar Graph'];
   const firstLoad = (!stats.payload || !stats.payload.length) && stats.pending;
 
   return (
     <Typography component="div">
       {graphList.map((Graph, index) => (
         <ListItem
-          key={names[index]}
-          header={names[index]}
+          key={graphNames[index]}
+          header={graphNames[index]}
           collapsible
           loading={stats.pending}
           loaderDelay={firstLoad ? 0 : 350}
@@ -117,7 +109,6 @@ const GraphList = ({ stats, unitNames, graphList }) => {
               className={classes.content}
               results={stats.payload}
               unitNames={unitNames}
-              colors={graphColors}
             />
           </GraphWrapper>
         </ListItem>
@@ -129,10 +120,6 @@ const GraphList = ({ stats, unitNames, graphList }) => {
 const Graphs = ({ stats, unitNames, config }) => {
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
-
-  const graphList = [
-    LineGraph, BarGraph, RadarGraph,
-  ];
 
   return mobile || config.desktopGraphList
     ? (

--- a/client/src/containers/Stats/Graphs.jsx
+++ b/client/src/containers/Stats/Graphs.jsx
@@ -32,8 +32,8 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const graphNames = ['Bar Graph', 'Line Graph', 'Radar Graph'];
-const graphList = [BarGraph, LineGraph, RadarGraph];
+const graphNames = ['Line Graph', 'Bar Graph', 'Radar Graph'];
+const graphList = [LineGraph, BarGraph, RadarGraph];
 
 const GraphWrapper = ({
   loading, error, children, numUnits,

--- a/client/src/containers/Stats/Graphs.jsx
+++ b/client/src/containers/Stats/Graphs.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import Tabbed from 'components/Tabbed';
 import { BarGraph, LineGraph, RadarGraph } from 'components/Graphs';
@@ -125,7 +126,7 @@ const GraphList = ({ stats, unitNames, graphList }) => {
   );
 };
 
-const Graphs = ({ stats, unitNames }) => {
+const Graphs = ({ stats, unitNames, config }) => {
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
 
@@ -133,7 +134,7 @@ const Graphs = ({ stats, unitNames }) => {
     LineGraph, BarGraph, RadarGraph,
   ];
 
-  return mobile
+  return mobile || config.desktopGraphList
     ? (
       <GraphList
         stats={stats}
@@ -150,5 +151,8 @@ const Graphs = ({ stats, unitNames }) => {
     );
 };
 
+const mapStateToProps = (state) => ({
+  config: state.config,
+});
 
-export default Graphs;
+export default connect(mapStateToProps)(Graphs);

--- a/client/src/containers/Stats/Results.jsx
+++ b/client/src/containers/Stats/Results.jsx
@@ -24,7 +24,7 @@ const Results = ({ stats, unitNames, className }) => {
   return (
     <Typography className={clsx(classes.results, className)} component="div">
       <ListItem
-        header="Table"
+        header="Average Damage Table"
         collapsible
         loading={stats.pending}
         loaderDelay={firstLoad ? 0 : 350}

--- a/client/src/containers/Stats/Results.jsx
+++ b/client/src/containers/Stats/Results.jsx
@@ -3,6 +3,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import { Typography } from '@material-ui/core';
 import ListItem from 'components/ListItem';
+import _ from 'lodash';
 import Graphs from './Graphs';
 import ResultsTable from './ResultsTable';
 
@@ -17,7 +18,7 @@ const useStyles = makeStyles({
   },
 });
 
-const Results = ({ stats, unitNames, className }) => {
+const Results = React.memo(({ stats, unitNames, className }) => {
   const classes = useStyles();
   const firstLoad = (!stats.payload || !stats.payload.length) && stats.pending;
 
@@ -34,6 +35,6 @@ const Results = ({ stats, unitNames, className }) => {
       <Graphs stats={stats} unitNames={unitNames} />
     </Typography>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 export default Results;

--- a/client/src/containers/Stats/ResultsTable.jsx
+++ b/client/src/containers/Stats/ResultsTable.jsx
@@ -9,7 +9,9 @@ import StatsErrorCard from 'components/StatsErrorCard';
 
 
 const useStyles = makeStyles((theme) => ({
-  table: {},
+  table: {
+    background: theme.palette.background.nested,
+  },
   skeleton: {},
   container: {
     overflowX: 'scroll',
@@ -20,7 +22,7 @@ const useStyles = makeStyles((theme) => ({
     zIndex: 11,
   },
   header: {
-    backgroundColor: theme.palette.background.default,
+    fontWeight: theme.typography.fontWeightBold,
   },
   cell: {
     background: theme.palette.background.palette,

--- a/client/src/containers/Unit/Unit.jsx
+++ b/client/src/containers/Unit/Unit.jsx
@@ -8,7 +8,7 @@ import { addNotification } from 'actions/notifications.action';
 import { addWeaponProfile } from 'actions/weaponProfiles.action';
 import ListItem from 'components/ListItem';
 import { TextField, Button } from '@material-ui/core';
-import { Add } from '@material-ui/icons';
+import { Add, Delete, FileCopy } from '@material-ui/icons';
 import { makeStyles } from '@material-ui/core/styles';
 import { MAX_PROFILES } from 'appConstants';
 import clsx from 'clsx';
@@ -67,14 +67,20 @@ const Unit = ({
   const moveUnitUp = () => { moveUnit(id, id - 1); };
   const moveUnitDown = () => { moveUnit(id, id + 1); };
 
+  const numProfiles = unit.weapon_profiles ? unit.weapon_profiles.length : 0;
+
   return (
     <div ref={unitRef}>
       <ListItem
         className={clsx(classes.unit, className)}
         header={`Unit (${unit.name})`}
-        onDelete={() => handleDeleteUnit(id)}
-        onCopy={addUnitEnabled() ? copyUnit : 'disabled'}
-        extraItems={[
+        primaryItems={[
+          {
+            name: 'Copy', onClick: copyUnit, icon: <FileCopy />, disabled: !addUnitEnabled(),
+          },
+          { name: 'Delete', onClick: () => handleDeleteUnit(id), icon: <Delete /> },
+        ]}
+        secondaryItems={[
           { name: 'Export', onClick: exportUnit },
           { name: 'Move Up', onClick: moveUnitUp, disabled: !moveUpEnabled },
           { name: 'Move Down', onClick: moveUnitDown, disabled: !moveDownEnabled },
@@ -98,6 +104,7 @@ const Unit = ({
                 profile={profile}
                 key={profile.uuid}
                 addProfileEnabled={addProfileEnabled}
+                numProfiles={numProfiles}
               />
             ))
             : (

--- a/client/src/containers/Unit/Unit.jsx
+++ b/client/src/containers/Unit/Unit.jsx
@@ -116,6 +116,7 @@ const Unit = React.memo(({
                 header="No Profiles"
                 body="No profiles have been added for this unit"
                 dense
+                nested
               />
             )}
         </div>

--- a/client/src/containers/Unit/Unit.jsx
+++ b/client/src/containers/Unit/Unit.jsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useRef, useCallback } from 'react';
+import PropTypes from 'prop-types';
 import WeaponProfile from 'containers/WeaponProfile';
 import { connect } from 'react-redux';
 import {
@@ -133,6 +134,27 @@ const Unit = React.memo(({
     </div>
   );
 }, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
+
+Unit.defaultProps = {
+  className: null,
+};
+
+Unit.propTypes = {
+  id: PropTypes.number.isRequired,
+  unit: PropTypes.shape({
+    name: PropTypes.string.isRequired,
+    uuid: PropTypes.string.isRequired,
+    weapon_profiles: PropTypes.array,
+  }).isRequired,
+  addWeaponProfile: PropTypes.func.isRequired,
+  deleteUnit: PropTypes.func.isRequired,
+  editUnitName: PropTypes.func.isRequired,
+  addUnit: PropTypes.func.isRequired,
+  className: PropTypes.string,
+  addNotification: PropTypes.func.isRequired,
+  moveUnit: PropTypes.func.isRequired,
+  numUnits: PropTypes.number.isRequired,
+};
 
 const mapStateToProps = (state) => ({
   numUnits: state.units.length,

--- a/client/src/containers/Unit/Unit.jsx
+++ b/client/src/containers/Unit/Unit.jsx
@@ -124,6 +124,10 @@ const Unit = ({
   );
 };
 
-export default connect(null, {
+const mapStateToProps = (state) => ({
+  units: state.units,
+});
+
+export default connect(mapStateToProps, {
   addWeaponProfile, deleteUnit, editUnitName, addUnit, addNotification, moveUnit,
 })(Unit);

--- a/client/src/containers/Unit/Unit.jsx
+++ b/client/src/containers/Unit/Unit.jsx
@@ -1,7 +1,9 @@
 import React, { useEffect, useRef, useCallback } from 'react';
 import WeaponProfile from 'containers/WeaponProfile';
 import { connect } from 'react-redux';
-import { deleteUnit, editUnitName, addUnit } from 'actions/units.action';
+import {
+  deleteUnit, editUnitName, addUnit, moveUnit,
+} from 'actions/units.action';
 import { addNotification } from 'actions/notifications.action';
 import { addWeaponProfile } from 'actions/weaponProfiles.action';
 import ListItem from 'components/ListItem';
@@ -11,7 +13,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { MAX_PROFILES } from 'appConstants';
 import clsx from 'clsx';
 import NoItemsCard from 'components/NoItemsCard';
-import { addUnitEnabled } from 'utils/unitHelpers';
+import { addUnitEnabled, getNumUnits } from 'utils/unitHelpers';
 
 
 const useStyles = makeStyles((theme) => ({
@@ -27,14 +29,15 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const Unit = ({
-  id, unit, addWeaponProfile, deleteUnit, editUnitName, addUnit, className, addNotification,
+  id, unit, addWeaponProfile, deleteUnit, editUnitName, addUnit, className,
+  addNotification, moveUnit,
 }) => {
   const unitRef = useRef(null);
   const classes = useStyles();
 
   useEffect(() => {
     if (unitRef.current) unitRef.current.scrollIntoView({ behavior: 'smooth' });
-  }, [id]);
+  }, [unit.uuid]);
 
   const handleDeleteUnit = useCallback((id) => {
     addNotification({ message: 'Deleted Unit' });
@@ -52,11 +55,17 @@ const Unit = ({
   }, [unit, addNotification]);
 
   const addProfileEnabled = unit.weapon_profiles.length < MAX_PROFILES;
+  const moveUpEnabled = id > 0;
+  const moveDownEnabled = id < getNumUnits() - 1;
+
   const unitNameError = (!unit.name || unit.name === '');
 
   const copyUnit = () => {
     addUnit(`${unit.name} copy`, [...unit.weapon_profiles]);
   };
+
+  const moveUnitUp = () => { moveUnit(id, id - 1); };
+  const moveUnitDown = () => { moveUnit(id, id + 1); };
 
   return (
     <div ref={unitRef}>
@@ -65,7 +74,11 @@ const Unit = ({
         header={`Unit (${unit.name})`}
         onDelete={() => handleDeleteUnit(id)}
         onCopy={addUnitEnabled() ? copyUnit : 'disabled'}
-        extraItems={[{ name: 'Export', onClick: exportUnit }]}
+        extraItems={[
+          { name: 'Export', onClick: exportUnit },
+          { name: 'Move Up', onClick: moveUnitUp, disabled: !moveUpEnabled },
+          { name: 'Move Down', onClick: moveUnitDown, disabled: !moveDownEnabled },
+        ]}
         collapsible
       >
         <TextField
@@ -112,5 +125,5 @@ const Unit = ({
 };
 
 export default connect(null, {
-  addWeaponProfile, deleteUnit, editUnitName, addUnit, addNotification,
+  addWeaponProfile, deleteUnit, editUnitName, addUnit, addNotification, moveUnit,
 })(Unit);

--- a/client/src/containers/Units/Units.jsx
+++ b/client/src/containers/Units/Units.jsx
@@ -8,6 +8,7 @@ import clsx from 'clsx';
 import NoItemsCard from 'components/NoItemsCard';
 import { Route } from 'react-router-dom';
 import ProfileDialog from 'containers/ProfileDialog';
+import _ from 'lodash';
 import AddUnitButton from './AddUnitButton';
 
 const useStyles = makeStyles((theme) => ({
@@ -22,7 +23,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const Units = ({ units, addUnit, className }) => {
+const Units = React.memo(({ units, addUnit, className }) => {
   const classes = useStyles();
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
@@ -40,7 +41,7 @@ const Units = ({ units, addUnit, className }) => {
       </Route>
     </div>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 const mapStateToProps = (state) => ({ units: state.units });
 

--- a/client/src/containers/Units/Units.jsx
+++ b/client/src/containers/Units/Units.jsx
@@ -6,6 +6,7 @@ import { useMediaQuery } from '@material-ui/core';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import NoItemsCard from 'components/NoItemsCard';
+import PropTypes from 'prop-types';
 import { Route } from 'react-router-dom';
 import ProfileDialog from 'containers/ProfileDialog';
 import _ from 'lodash';
@@ -42,6 +43,16 @@ const Units = React.memo(({ units, addUnit, className }) => {
     </div>
   );
 }, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
+
+Units.defaultProps = {
+  className: null,
+};
+
+Units.propTypes = {
+  units: PropTypes.arrayOf(PropTypes.object).isRequired,
+  addUnit: PropTypes.func.isRequired,
+  className: PropTypes.string,
+};
 
 const mapStateToProps = (state) => ({ units: state.units });
 

--- a/client/src/containers/WeaponProfile/Characteristics.jsx
+++ b/client/src/containers/WeaponProfile/Characteristics.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Typography, Tooltip } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import clsx from 'clsx';
@@ -61,6 +62,23 @@ const Characteristics = ({ profile, className, ...other }) => {
       <Characteristic name="Damage" text={`${profile.damage}`} />
     </Typography>
   );
+};
+
+Characteristics.defaultProps = {
+  className: null,
+};
+
+Characteristics.propTypes = {
+  profile: PropTypes.shape({
+    num_models: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    attacks: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    to_hit: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    to_wound: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    rend: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    damage: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+    modifiers: PropTypes.arrayOf(PropTypes.object),
+  }).isRequired,
+  className: PropTypes.string,
 };
 
 export default Characteristics;

--- a/client/src/containers/WeaponProfile/WeaponProfile.jsx
+++ b/client/src/containers/WeaponProfile/WeaponProfile.jsx
@@ -15,6 +15,7 @@ import ModifierSummary from 'components/ModifierSummary';
 import { useHistory } from 'react-router-dom';
 import { getUnitByPosition } from 'utils/unitHelpers';
 import { Delete, FileCopy, Edit } from '@material-ui/icons';
+import _ from 'lodash';
 import Characteristics from './Characteristics';
 
 const useStyles = makeStyles((theme) => ({
@@ -41,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-const WeaponProfile = ({
+const WeaponProfile = React.memo(({
   unitId, id, profile, toggleWeaponProfile, deleteWeaponProfile, numProfiles,
   addWeaponProfile, addProfileEnabled, addNotification, moveWeaponProfile,
 }) => {
@@ -122,7 +123,7 @@ const WeaponProfile = ({
       </ListItem>
     </div>
   );
-};
+}, (prevProps, nextProps) => _.isEqual(prevProps, nextProps));
 
 WeaponProfile.defaultProps = {
   numProfiles: 0,

--- a/client/src/containers/WeaponProfile/WeaponProfile.jsx
+++ b/client/src/containers/WeaponProfile/WeaponProfile.jsx
@@ -4,7 +4,7 @@ import React, {
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import {
-  toggleWeaponProfile, deleteWeaponProfile, addWeaponProfile,
+  toggleWeaponProfile, deleteWeaponProfile, addWeaponProfile, moveWeaponProfile,
 } from 'actions/weaponProfiles.action';
 import { addNotification } from 'actions/notifications.action';
 import { Switch } from '@material-ui/core';
@@ -42,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
 
 const WeaponProfile = ({
   unitId, id, profile, toggleWeaponProfile, deleteWeaponProfile,
-  addWeaponProfile, addProfileEnabled, addNotification,
+  addWeaponProfile, addProfileEnabled, addNotification, moveWeaponProfile,
 }) => {
   const classes = useStyles();
   const profileRef = useRef(null);
@@ -53,7 +53,7 @@ const WeaponProfile = ({
 
   useEffect(() => {
     if (profileRef.current) profileRef.current.scrollIntoView({ behavior: 'smooth' });
-  }, [id]);
+  }, [profile.uuid]);
 
   const handleOpen = useCallback(() => {
     history.push(editPath);
@@ -64,6 +64,12 @@ const WeaponProfile = ({
     deleteWeaponProfile(id, unitId);
   }, [addNotification, deleteWeaponProfile]);
 
+  const moveUpEnabled = id > 0;
+  const moveDownEnabled = id < (unit.weapon_profiles.length - 1);
+
+  const moveProfileUp = () => { moveWeaponProfile(id, id - 1, unitId); };
+  const moveProfileDown = () => { moveWeaponProfile(id, id + 1, unitId); };
+
   return (
     <div ref={profileRef}>
       <ListItem
@@ -72,6 +78,10 @@ const WeaponProfile = ({
         onEdit={handleOpen}
         onDelete={() => handleDelete(id, unitId)}
         onCopy={addProfileEnabled ? () => addWeaponProfile(unitId, { ...profile }) : 'disabled'}
+        extraItems={[
+          { name: 'Move Up', onClick: moveProfileUp, disabled: !moveUpEnabled },
+          { name: 'Move Down', onClick: moveProfileDown, disabled: !moveDownEnabled },
+        ]}
         collapsible
       >
         <div className={classes.content}>
@@ -104,8 +114,9 @@ WeaponProfile.propTypes = {
   addWeaponProfile: PropTypes.func.isRequired,
   addProfileEnabled: PropTypes.bool.isRequired,
   addNotification: PropTypes.func.isRequired,
+  moveWeaponProfile: PropTypes.func.isRequired,
 };
 
 export default connect(null, {
-  toggleWeaponProfile, deleteWeaponProfile, addWeaponProfile, addNotification,
+  toggleWeaponProfile, deleteWeaponProfile, addWeaponProfile, addNotification, moveWeaponProfile,
 })(WeaponProfile);

--- a/client/src/containers/WeaponProfile/WeaponProfile.jsx
+++ b/client/src/containers/WeaponProfile/WeaponProfile.jsx
@@ -49,26 +49,39 @@ const WeaponProfile = ({
   const profileRef = useRef(null);
   const history = useHistory();
 
+  /** The unit that this profile belongs to */
   const unit = useMemo(() => getUnitByPosition(unitId), [unitId]);
+  /** The URL used to open an edit dialog for this item */
   const editPath = `/units/${unit.uuid}/${id}`;
 
+  // Scroll to the component when it is first created
   useEffect(() => {
     if (profileRef.current) profileRef.current.scrollIntoView({ behavior: 'smooth' });
   }, [profile.uuid]);
 
+  /** Handle open/close of the edit profile dialog */
   const handleOpen = useCallback(() => {
     history.push(editPath);
   }, [editPath, history]);
 
+  /**
+   * Handle the delete button for the profile
+   * @param {int} id The index of the profile to delete
+   * @param {int} unitId The index of the unit that this profile belongs to
+   */
   const handleDelete = useCallback((id, unitId) => {
     addNotification({ message: 'Deleted Profile' });
     deleteWeaponProfile(id, unitId);
   }, [addNotification, deleteWeaponProfile]);
 
+  /** Whether the move up button is enabled or not */
   const moveUpEnabled = id > 0;
+  /** Whether the move down button is enabled or not */
   const moveDownEnabled = id < (numProfiles - 1);
 
+  /** Move this profile up by one space */
   const moveProfileUp = () => { moveWeaponProfile(id, id - 1, unitId); };
+  /** Move this profile down by one space */
   const moveProfileDown = () => { moveWeaponProfile(id, id + 1, unitId); };
 
   return (
@@ -86,9 +99,6 @@ const WeaponProfile = ({
           },
           { name: 'Delete', onClick: () => handleDelete(id, unitId), icon: <Delete /> },
         ]}
-        onEdit={handleOpen}
-        onDelete={() => handleDelete(id, unitId)}
-        onCopy={addProfileEnabled ? () => addWeaponProfile(unitId, { ...profile }) : 'disabled'}
         secondaryItems={[
           { name: 'Move Up', onClick: moveProfileUp, disabled: !moveUpEnabled },
           { name: 'Move Down', onClick: moveProfileDown, disabled: !moveDownEnabled },
@@ -123,6 +133,8 @@ WeaponProfile.propTypes = {
   id: PropTypes.number.isRequired,
   profile: PropTypes.shape({
     uuid: PropTypes.string.isRequired,
+    modifiers: PropTypes.array,
+    active: PropTypes.bool,
   }).isRequired,
   toggleWeaponProfile: PropTypes.func.isRequired,
   deleteWeaponProfile: PropTypes.func.isRequired,

--- a/client/src/containers/WeaponProfile/WeaponProfile.jsx
+++ b/client/src/containers/WeaponProfile/WeaponProfile.jsx
@@ -19,6 +19,7 @@ import Characteristics from './Characteristics';
 const useStyles = makeStyles((theme) => ({
   profile: {
     display: 'flex',
+    background: theme.palette.background.nested,
   },
   inactive: {
     color: theme.palette.action.disabled,

--- a/client/src/containers/WeaponProfile/WeaponProfile.jsx
+++ b/client/src/containers/WeaponProfile/WeaponProfile.jsx
@@ -14,6 +14,7 @@ import clsx from 'clsx';
 import ModifierSummary from 'components/ModifierSummary';
 import { useHistory } from 'react-router-dom';
 import { getUnitByPosition } from 'utils/unitHelpers';
+import { Delete, FileCopy, Edit } from '@material-ui/icons';
 import Characteristics from './Characteristics';
 
 const useStyles = makeStyles((theme) => ({
@@ -41,7 +42,7 @@ const useStyles = makeStyles((theme) => ({
 }));
 
 const WeaponProfile = ({
-  unitId, id, profile, toggleWeaponProfile, deleteWeaponProfile,
+  unitId, id, profile, toggleWeaponProfile, deleteWeaponProfile, numProfiles,
   addWeaponProfile, addProfileEnabled, addNotification, moveWeaponProfile,
 }) => {
   const classes = useStyles();
@@ -65,7 +66,7 @@ const WeaponProfile = ({
   }, [addNotification, deleteWeaponProfile]);
 
   const moveUpEnabled = id > 0;
-  const moveDownEnabled = id < (unit.weapon_profiles.length - 1);
+  const moveDownEnabled = id < (numProfiles - 1);
 
   const moveProfileUp = () => { moveWeaponProfile(id, id - 1, unitId); };
   const moveProfileDown = () => { moveWeaponProfile(id, id + 1, unitId); };
@@ -75,10 +76,20 @@ const WeaponProfile = ({
       <ListItem
         className={clsx(classes.profile, profile.active ? '' : classes.inactive)}
         header="Weapon Profile"
+        primaryItems={[
+          { name: 'Edit', onClick: handleOpen, icon: <Edit /> },
+          {
+            name: 'Copy',
+            onClick: () => addWeaponProfile(unitId, { ...profile }),
+            icon: <FileCopy />,
+            disabled: !addProfileEnabled,
+          },
+          { name: 'Delete', onClick: () => handleDelete(id, unitId), icon: <Delete /> },
+        ]}
         onEdit={handleOpen}
         onDelete={() => handleDelete(id, unitId)}
         onCopy={addProfileEnabled ? () => addWeaponProfile(unitId, { ...profile }) : 'disabled'}
-        extraItems={[
+        secondaryItems={[
           { name: 'Move Up', onClick: moveProfileUp, disabled: !moveUpEnabled },
           { name: 'Move Down', onClick: moveProfileDown, disabled: !moveDownEnabled },
         ]}
@@ -103,6 +114,10 @@ const WeaponProfile = ({
   );
 };
 
+WeaponProfile.defaultProps = {
+  numProfiles: 0,
+};
+
 WeaponProfile.propTypes = {
   unitId: PropTypes.number.isRequired,
   id: PropTypes.number.isRequired,
@@ -115,6 +130,7 @@ WeaponProfile.propTypes = {
   addProfileEnabled: PropTypes.bool.isRequired,
   addNotification: PropTypes.func.isRequired,
   moveWeaponProfile: PropTypes.func.isRequired,
+  numProfiles: PropTypes.number,
 };
 
 export default connect(null, {

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -1,4 +1,5 @@
-import '@babel/polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -9,6 +9,7 @@ import { PersistGate } from 'redux-persist/integration/react';
 import store, { persistor } from './store';
 import * as serviceWorker from './serviceWorker';
 
+
 ReactDOM.render(
   <Provider store={store}>
     <PersistGate loading={null} persistor={persistor}>

--- a/client/src/reducers/config.reducer.js
+++ b/client/src/reducers/config.reducer.js
@@ -1,8 +1,9 @@
-import { TOGGLE_DARK_MODE } from 'actions/config.action';
+import { TOGGLE_DARK_MODE, TOGGLE_DESKTOP_GRAPH_LIST } from 'actions/config.action';
 
 
 const DEFAULT_STATE = {
   darkMode: false,
+  desktopGraphList: false,
 };
 
 const toggleDarkMode = (state) => ({
@@ -10,10 +11,17 @@ const toggleDarkMode = (state) => ({
   darkMode: !state.darkMode,
 });
 
+const toggleDesktopGraphList = (state) => ({
+  ...state,
+  desktopGraphList: !state.desktopGraphList,
+});
+
 const configReducer = (state = DEFAULT_STATE, action) => {
   switch (action.type) {
     case TOGGLE_DARK_MODE:
       return toggleDarkMode(state, action);
+    case TOGGLE_DESKTOP_GRAPH_LIST:
+      return toggleDesktopGraphList(state, action);
     default:
       return state;
   }

--- a/client/src/reducers/helpers.js
+++ b/client/src/reducers/helpers.js
@@ -1,7 +1,13 @@
-/* eslint-disable import/prefer-default-export */
 export const updateItemInArray = (array, index, callback) => array.map((item, i) => {
   if (i === index) {
     return callback(item);
   }
   return item;
 });
+
+export const moveItemInArray = (array, index, newIndex, callback) => {
+  const newArray = array.slice();
+  const sanitizedNewIndex = Math.min(Math.max(newIndex, 0), array.length - 1);
+  newArray.splice(sanitizedNewIndex, 0, ...newArray.splice(index, 1));
+  return callback(newArray);
+};

--- a/client/src/reducers/units.reducer.js
+++ b/client/src/reducers/units.reducer.js
@@ -1,10 +1,10 @@
 import nanoid from 'nanoid';
 import {
-  ADD_UNIT, DELETE_UNIT, EDIT_UNIT_NAME, CLEAR_ALL_UNITS,
+  ADD_UNIT, DELETE_UNIT, EDIT_UNIT_NAME, CLEAR_ALL_UNITS, MOVE_UNIT,
 } from '../actions/units.action';
 import { DEFAULT_WEAPON_PROFILE } from '../actions/weaponProfiles.action';
 import weaponProfilesReducer from './weaponProfiles.reducer';
-import { updateItemInArray } from './helpers';
+import { updateItemInArray, moveItemInArray } from './helpers';
 
 const DEFAULT_UNIT = {
   name: 'Unit 1',
@@ -35,7 +35,11 @@ const editUnitName = (state, action) => updateItemInArray(state, action.unitId, 
   name: action.name,
 }));
 
-const clearAllUnits = (state, action) => [];
+const clearAllUnits = () => [];
+
+const moveUnit = (state, action) => (
+  moveItemInArray(state, action.index, action.newIndex, (newState) => newState)
+);
 
 const unitReducer = (state, action) => {
   switch (action.type) {
@@ -57,6 +61,8 @@ const unitsReducer = (state = INITIAL_STATE, action) => {
       return editUnitName(state, action);
     case CLEAR_ALL_UNITS:
       return clearAllUnits(state, action);
+    case MOVE_UNIT:
+      return moveUnit(state, action);
     default:
       if (action && typeof action.unitId === 'number') {
         return state.map((unit, index) => {

--- a/client/src/reducers/weaponProfiles.reducer.js
+++ b/client/src/reducers/weaponProfiles.reducer.js
@@ -1,8 +1,9 @@
 import nanoid from 'nanoid';
 import {
   TOGGLE_WEAPON_PROFILE, EDIT_WEAPON_PROFILE, ADD_WEAPON_PROFILE, DELETE_WEAPON_PROFILE,
+  MOVE_WEAPON_PROFILE,
 } from '../actions/weaponProfiles.action';
-import { updateItemInArray } from './helpers';
+import { updateItemInArray, moveItemInArray } from './helpers';
 
 const addWeaponProfile = (state, action) => [
   ...state,
@@ -21,6 +22,10 @@ const editWeaponProfile = (state, action) => updateItemInArray(state, action.id,
 
 const deleteWeaponProfile = (state, action) => state.filter((_, index) => index !== action.id);
 
+const moveWeaponProfile = (state, action) => (
+  moveItemInArray(state, action.index, action.newIndex, (newState) => newState)
+);
+
 const weaponProfilesReducer = (state, action) => {
   switch (action.type) {
     case TOGGLE_WEAPON_PROFILE:
@@ -31,6 +36,8 @@ const weaponProfilesReducer = (state, action) => {
       return addWeaponProfile(state, action);
     case DELETE_WEAPON_PROFILE:
       return deleteWeaponProfile(state, action);
+    case MOVE_WEAPON_PROFILE:
+      return moveWeaponProfile(state, action);
     default:
       return state;
   }

--- a/client/src/themes.js
+++ b/client/src/themes.js
@@ -8,6 +8,7 @@ const lightTheme = createMuiTheme({
       nested: '#fff',
       paper: '#fff',
       default: grey[100],
+      error: red.A100,
     },
     graphs: {
       grid: grey[300],
@@ -43,6 +44,7 @@ const darkTheme = createMuiTheme({
       nested: grey[800],
       paper: '#333',
       default: grey[900],
+      error: red.A100,
     },
     graphs: {
       grid: grey[700],

--- a/client/src/themes.js
+++ b/client/src/themes.js
@@ -1,9 +1,14 @@
 import { createMuiTheme } from '@material-ui/core/styles';
-import { grey } from '@material-ui/core/colors';
+import { grey, red, teal } from '@material-ui/core/colors';
 
 const lightTheme = createMuiTheme({
   palette: {
     type: 'light',
+    background: {
+      nested: '#fff',
+      paper: '#fff',
+      default: grey[100],
+    },
     graphs: {
       grid: grey[300],
       axis: grey[700],
@@ -29,10 +34,15 @@ const darkTheme = createMuiTheme({
   palette: {
     type: 'dark',
     primary: {
-      main: '#5c6bc0',
+      main: teal[500],
     },
     secondary: {
-      main: '#ff5252',
+      main: red[500],
+    },
+    background: {
+      nested: grey[800],
+      paper: '#333',
+      default: grey[900],
     },
     graphs: {
       grid: grey[700],

--- a/client/src/utils/configHelpers.js
+++ b/client/src/utils/configHelpers.js
@@ -1,0 +1,5 @@
+import store from 'store';
+
+export const isDarkModeEnabled = () => store.getState().config.darkMode;
+
+export const isDesktopGraphListEnabled = () => store.getState().config.desktopGraphList;

--- a/client/src/utils/unitHelpers.js
+++ b/client/src/utils/unitHelpers.js
@@ -3,6 +3,8 @@ import { MAX_UNITS } from 'appConstants';
 
 export const getUnits = () => store.getState().units;
 
+export const getNumUnits = () => getUnits().length;
+
 export const getUnitByUuid = (uuid) => getUnits().find((unit) => unit.uuid === uuid);
 
 export const getUnitIndexByUuid = (uuid) => (

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer-express",
-    "version": "0.3.3",
+    "version": "0.4.0",
     "engines": {
         "node": "12.13.1",
         "yarn": "1.19.2"

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
         "@babel/register": "^7.7.4",
         "babel-plugin-import": "^1.13.0",
         "body-parser": "^1.18.3",
+        "core-js": "^3.5.0",
         "eslint": "^6.7.2",
         "eslint-config-airbnb": "^18.0.1",
         "eslint-plugin-import": "^2.18.2",
@@ -30,7 +31,8 @@
         "eslint-plugin-react-hooks": "^2.3.0",
         "esm": "^3.2.25",
         "express": "^4.16.4",
-        "mocha": "^6.2.2"
+        "mocha": "^6.2.2",
+        "regenerator-runtime": "^0.13.3"
     },
     "devDependencies": {
         "concurrently": "^4.0.1"

--- a/server.js
+++ b/server.js
@@ -1,4 +1,5 @@
-import '@babel/polyfill';
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
 import express from 'express';
 import bodyParser from 'body-parser';
 import path from 'path';


### PR DESCRIPTION
## Changes

- Added support for full dice notation (e.g: `2D6 + 2`)
- Added re-ordering of lists (`units`, `weapon profiles`, and `modifiers`)
    - These will just be buttons for now
- Added ability to change the desktop graph view between list / tabbed
- Improved dark mode for increased visibility and better contrast
- Added icons to the AppBar menu
- Added graph axis labels to better identify graph intent

## Fixes

- Use `React.memo` and `_.isEqual` to avoid unnecessary re-renders when props
- Ensure that `attacks`, and `damage` characteristics never go lower than 1
- Fix a safari specific bug which caused the modifier inputs to change order when their values changed
- Move from deprecated `@babel/polyfill` -> `core-js` and `regenerator-runtime`
