### PR TITLE
[0.6.2] Split Simulation calls by save to allow them to be called in parallel

### DIFF
--- a/api/processors/simulation.js
+++ b/api/processors/simulation.js
@@ -42,7 +42,7 @@ class Simulation {
 
   resolveHitRoll() {
     const hitRoll = this.performReroll(C.TO_HIT, D6.roll());
-    if (hitRoll >= this.profile.getToHit()) {
+    if (hitRoll >= this.profile.getToHit(false, true)) {
       const explodingModifier = this.profile.modifiers.getModifier(m.EXPLODING, C.TO_HIT);
       if (explodingModifier && hitRoll >= explodingModifier.on) {
         return [...Array(explodingModifier.getExtra(true) + 1)].reduce((acc) => (
@@ -73,7 +73,7 @@ class Simulation {
 
   resolveWoundRoll() {
     const woundRoll = this.performReroll(C.TO_WOUND, D6.roll());
-    if (woundRoll >= this.profile.getToWound()) {
+    if (woundRoll >= this.profile.getToWound(false, true)) {
       const explodingModifier = this.profile.modifiers.getModifier(m.EXPLODING, C.TO_WOUND);
       if (explodingModifier && woundRoll >= explodingModifier.on) {
         return [...Array(explodingModifier.getExtra(true) + 1)].reduce((acc) => (
@@ -104,7 +104,7 @@ class Simulation {
 
   resolveSaveRoll() {
     const saveRoll = D6.roll();
-    const save = this.target.getSaveAfterRend(this.profile.getRend());
+    const save = this.target.getSaveAfterRend(this.profile.getRend(false, true));
     if (!save || saveRoll < save) {
       return this.resolveDamage();
     }
@@ -112,7 +112,7 @@ class Simulation {
   }
 
   resolveDamage() {
-    return this.profile.getDamage();
+    return this.profile.getDamage(false, true);
   }
 
   performReroll(characteristic, roll) {

--- a/api/utils.js
+++ b/api/utils.js
@@ -3,11 +3,9 @@
  * @param {int} min The minimum value (inclusive)
  * @param {int} max The maximum value (inclusive)
  */
-export const getRandomInt = (min, max) => {
-  const minVal = Math.ceil(min);
-  const maxVal = Math.floor(max);
-  return Math.floor(Math.random() * (maxVal - minVal + 1)) + minVal;
-};
+export const getRandomInt = (min, max) => (
+  min + Math.floor(Math.random() * (max - min + 1))
+);
 
 export const getSum = (array) => array.reduce((acc, n) => acc + n, 0);
 

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "private": true,
     "proxy": "http://localhost:5000/",
     "engines": {

--- a/client/src/api.js
+++ b/client/src/api.js
@@ -81,14 +81,8 @@ export const fetchSimulations = () => async (dispatch) => {
       fetchSimulationForSave(units, save, 5000).then((data) => data.json())
     )));
     const res = responses.reduce((acc, { results, probabilities }) => ({
-      results: [
-        ...acc.results,
-        results,
-      ],
-      probabilities: [
-        ...acc.probabilities,
-        probabilities,
-      ],
+      results: [...acc.results, results],
+      probabilities: [...acc.probabilities, probabilities],
     }), { results: [], probabilities: [] });
     dispatch(fetchSimulationsSuccess(res.results, res.probabilities));
   } catch (error) {

--- a/client/src/components/Drawer/Drawer.jsx
+++ b/client/src/components/Drawer/Drawer.jsx
@@ -79,7 +79,7 @@ const Drawer = ({ open, onClose, page }) => {
         <Divider className={classes.divider} variant="middle" />
         <SocialItems />
         <Divider className={classes.divider} variant="middle" />
-        <Typography variant="caption" className={classes.version}>v0.6.0</Typography>
+        <Typography variant="caption" className={classes.version}>v0.6.2</Typography>
       </List>
     </AppDrawer>
   );

--- a/client/src/pdf/generator/generate.js
+++ b/client/src/pdf/generator/generate.js
@@ -193,7 +193,7 @@ const generate = async (
   cursor.reset();
   cursor.incr(20);
   doc.text('Probabilities', doc.internal.pageSize.getWidth() / 2, cursor.pos, { align: 'center' });
-  cursor.incr(10);
+  cursor.incr(20);
   await addGraphs(doc, probabilitiesClassName);
   return doc;
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer-express",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "engines": {
         "node": "12.13.1",
         "yarn": "1.19.2"


### PR DESCRIPTION
# Changes
- Rather than doing 1 `/simulate` call, do 6 `/simulate/save` calls (one for each save) in parallel, and then combine them.
    - This should allow each call to be handled by a different express worker, speeding up the total request time

# Architecture

- Set the number of express workers to the CPU count (no arbitrary limit)
- Add a function that creates a new worker if it detects one has died
- Fix damage simulation taking average roll