### PR TITLE
[1.1.1] Change buttons to icons on xs screens for simulation top bar

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "private": true,
     "proxy": "http://localhost:5000/",
     "engines": {

--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -5,7 +5,7 @@ import { AppBar as Bar, Toolbar, Typography, IconButton, useScrollTrigger, Slide
 import { Menu as MenuIcon } from '@material-ui/icons';
 import Drawer from 'components/Drawer';
 import Link from 'components/Link';
-import { useHashMatch } from 'hooks';
+import { useHashMatch, useBreakpointChanged } from 'hooks';
 import { EPages, getRoute } from 'types/routes';
 
 interface StyleProps {
@@ -57,6 +57,8 @@ const AppBar: React.FC<IAppBarProps> = ({ title = 'AoS Statshammer', variant = E
   const drawerOpen = useHashMatch('#menu');
   const trigger = useScrollTrigger();
 
+  const breakpoints = useBreakpointChanged();
+
   const handleDrawerClose = () => {
     history.goBack();
   };
@@ -66,10 +68,12 @@ const AppBar: React.FC<IAppBarProps> = ({ title = 'AoS Statshammer', variant = E
   };
 
   useEffect(() => {
-    if (ref && ref.current) {
-      setHeight(ref.current.clientHeight);
-    }
-  }, [ref]);
+    setTimeout(() => {
+      if (ref && ref.current) {
+        setHeight(ref.current.clientHeight);
+      }
+    }, 300);
+  }, [ref, breakpoints]);
 
   return (
     <div className={classes.appBar}>

--- a/client/src/components/SimulationInfoModal/SimulationInfoModal.tsx
+++ b/client/src/components/SimulationInfoModal/SimulationInfoModal.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { Dialog, DialogTitle, Button, DialogContent, DialogActions, IconButton } from '@material-ui/core';
-import { makeStyles, Theme } from '@material-ui/core/styles';
+import {
+  Dialog,
+  DialogTitle,
+  Button,
+  DialogContent,
+  DialogActions,
+  IconButton,
+  useMediaQuery,
+  Tooltip,
+} from '@material-ui/core';
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import { Close, InfoOutlined } from '@material-ui/icons';
 import { useHashMatch, useReadFromFile } from 'hooks';
 import { useHistory } from 'react-router-dom';
@@ -22,6 +31,9 @@ const SimulationInfoModal = () => {
   const classes = useStyles();
   const open = useHashMatch('#info');
   const history = useHistory();
+  const theme = useTheme();
+
+  const xs = useMediaQuery(theme.breakpoints.down('xs'));
   const numSimulations = useSelector((state: IStore) => state.config.numSimulations);
   const content = useReadFromFile('simInfo.md', { numSim: numSimulations, totSim: numSimulations * 6 });
 
@@ -35,9 +47,17 @@ const SimulationInfoModal = () => {
 
   return (
     <>
-      <Button onClick={handleOpen} endIcon={<InfoOutlined />}>
-        Info
-      </Button>
+      {xs ? (
+        <Tooltip title="Info">
+          <IconButton onClick={handleOpen}>
+            <InfoOutlined />
+          </IconButton>
+        </Tooltip>
+      ) : (
+        <Button onClick={handleOpen} endIcon={<InfoOutlined />}>
+          Info
+        </Button>
+      )}
       <Dialog open={open} onClose={handleClose} fullWidth maxWidth="md" scroll="paper">
         <DialogTitle className={classes.title}>
           <IconButton onClick={handleClose} size="small" className={classes.closeIcon}>

--- a/client/src/components/SimulationTabControls/SimulationTabControls.tsx
+++ b/client/src/components/SimulationTabControls/SimulationTabControls.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import SimulationInfoModal from 'components/SimulationInfoModal';
-import { Button, useMediaQuery } from '@material-ui/core';
+import { IconButton, Button, useMediaQuery, Tooltip } from '@material-ui/core';
 import { ArrowBack, Refresh } from '@material-ui/icons';
 import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
 import { useHistory } from 'react-router-dom';
@@ -42,6 +42,7 @@ const SimulationTabControls: React.FC<ISimulationTabControlsProps> = ({ pending 
 
   const theme = useTheme();
   const md = useMediaQuery(theme.breakpoints.down('md'));
+  const xs = useMediaQuery(theme.breakpoints.down('xs'));
 
   const handleClick = () => {
     history.push(getRoute(EPages.HOME));
@@ -54,12 +55,29 @@ const SimulationTabControls: React.FC<ISimulationTabControlsProps> = ({ pending 
   return (
     <div className={classes.simTabControls}>
       <div className={classes.group}>
-        <Button startIcon={<ArrowBack />} className={classes.spacedItem} onClick={handleClick}>
-          Return
-        </Button>
-        <Button startIcon={<Refresh />} onClick={handleRerun} disabled={pending}>
-          {`Rerun ${md ? '' : 'Simulations'}`}
-        </Button>
+        {xs ? (
+          <>
+            <Tooltip title="Return">
+              <IconButton className={classes.spacedItem} onClick={handleClick}>
+                <ArrowBack />
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Rerun Simulations">
+              <IconButton className={classes.spacedItem} onClick={handleRerun}>
+                <Refresh />
+              </IconButton>
+            </Tooltip>
+          </>
+        ) : (
+          <>
+            <Button startIcon={<ArrowBack />} className={classes.spacedItem} onClick={handleClick}>
+              Return
+            </Button>
+            <Button startIcon={<Refresh />} onClick={handleRerun} disabled={pending}>
+              {`Rerun ${md ? '' : 'Simulations'}`}
+            </Button>
+          </>
+        )}
       </div>
       <div className={classes.group}>
         <SimulationConfigDialog />

--- a/client/src/hooks/index.tsx
+++ b/client/src/hooks/index.tsx
@@ -5,3 +5,4 @@ export { default as useHashMatch } from './useHashMatch';
 export { default as useMapping } from './useMapping';
 export { default as useReadFromFile } from './useReadFromFile';
 export { default as useIsMobile } from './useIsMobile';
+export { default as useBreakpointChanged } from './useBreakpointChanged';

--- a/client/src/hooks/useBreakpointChanged.tsx
+++ b/client/src/hooks/useBreakpointChanged.tsx
@@ -1,0 +1,17 @@
+import { useMediaQuery } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+
+const useBreakpointChanged = () => {
+  const theme = useTheme();
+  const breakpoints: boolean[] = [
+    useMediaQuery(theme.breakpoints.down('xs')),
+    useMediaQuery(theme.breakpoints.down('sm')),
+    useMediaQuery(theme.breakpoints.down('md')),
+    useMediaQuery(theme.breakpoints.down('lg')),
+    useMediaQuery(theme.breakpoints.down('xl')),
+  ];
+
+  return breakpoints;
+};
+
+export default useBreakpointChanged;

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
         "*",
         "."
     ],
-    "version": "1.1.0",
+    "version": "1.1.1",
     "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "statshammer-express",
     "private": true,
-    "version": "1.1.0",
+    "version": "1.1.1",
     "engines": {
         "node": "12.13.1",
         "yarn": "1.19.2"


### PR DESCRIPTION
## Fixes

- Small devices causing the `# Simulations` text to wrap over 2 lines.
    - Instead the other buttons will change to just IconButtons (with tooltips) for `xs` screens