### PR TITLE
2.1.0 UI Improvements

### DIFF
--- a/client/src/components/AppBar/AppBar.tsx
+++ b/client/src/components/AppBar/AppBar.tsx
@@ -5,16 +5,20 @@ import {
   Slide,
   Toolbar,
   Typography,
+  useMediaQuery,
   useScrollTrigger,
 } from '@material-ui/core';
-import { makeStyles, Theme } from '@material-ui/core/styles';
-import { Menu as MenuIcon } from '@material-ui/icons';
+import { makeStyles, Theme, useTheme } from '@material-ui/core/styles';
+import { ChevronLeft as ShrinkIcon, ChevronRight as GrowIcon, Menu as MenuIcon } from '@material-ui/icons';
+import clsx from 'clsx';
 import Link from 'components/Link';
 import SimulationTabControls from 'components/SimulationTabControls';
 import { useBreakpointChanged, useRouteFind } from 'hooks';
-import React, { useEffect, useRef, useState } from 'react';
-import { useSelector } from 'react-redux';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { useRailLgSelector } from 'store/selectors';
+import { configStore } from 'store/slices';
 import { HASHES, ROUTES } from 'utils/urls';
 
 import { IStore } from '../../types/store';
@@ -23,15 +27,13 @@ interface StyleProps {
   height: number;
 }
 const useStyles = makeStyles((theme: Theme) => ({
-  appBar: {
-    [theme.breakpoints.up('lg')]: {
-      marginLeft: theme.mixins.drawer.width,
-      width: `calc(100% - ${theme.mixins.drawer.width}px)`,
-    },
-    [theme.breakpoints.only('md')]: {
-      marginLeft: theme.mixins.drawer.miniWidth,
-      width: `calc(100% - ${theme.mixins.drawer.miniWidth}px)`,
-    },
+  largeMargin: {
+    marginLeft: theme.mixins.drawer.width,
+    width: `calc(100% - ${theme.mixins.drawer.width}px)`,
+  },
+  railMargin: {
+    marginLeft: theme.mixins.drawer.miniWidth,
+    width: `calc(100% - ${theme.mixins.drawer.miniWidth}px)`,
   },
   offset: ({ height }: StyleProps) => ({
     marginTop: height,
@@ -50,9 +52,6 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   menuButton: {
     color: theme.palette.getContrastText(theme.palette.primary.main),
-    [theme.breakpoints.up('lg')]: {
-      display: 'none',
-    },
   },
   title: {
     padding: theme.spacing(2, 0),
@@ -70,37 +69,63 @@ const AppBar = () => {
   const ref = useRef<HTMLDivElement>(null);
   const [height, setHeight] = useState(0);
   const [, , page] = useRouteFind(Object.values(ROUTES));
+  const dispatch = useDispatch();
 
-  const classes = useStyles({ height });
   const history = useHistory();
   const trigger = useScrollTrigger();
+  const classes = useStyles({ height });
+
+  const theme = useTheme();
+  const md = useMediaQuery(theme.breakpoints.up('md'));
+  const lg = useMediaQuery(theme.breakpoints.up('lg'));
+  const useRailLg = useSelector(useRailLgSelector);
 
   const breakpoints = useBreakpointChanged();
   const simulationsPending = useSelector((state: IStore) => state.simulations.pending);
 
+  const leftNavVariant = useMemo(() => {
+    if (lg) return useRailLg ? 'rail' : 'large';
+    if (md) return 'rail';
+    return 'none';
+  }, [lg, md, useRailLg]);
+
   const handleDrawerOpen = () => {
-    history.push(HASHES.DRAWER);
+    if (lg) {
+      dispatch(configStore.actions.toggleUseRailLg());
+    } else {
+      history.push(HASHES.DRAWER);
+    }
   };
 
   useEffect(() => {
     setTimeout(() => {
-      if (ref && ref.current) {
-        setHeight(ref.current.clientHeight);
-      }
+      if (ref && ref.current) setHeight(ref.current.clientHeight);
     }, 200);
   }, [ref, breakpoints]);
 
   return (
     <div>
       <Slide appear={false} direction="down" in={!trigger}>
-        <Bar className={classes.appBar}>
+        <Bar
+          className={clsx({
+            [classes.largeMargin]: leftNavVariant === 'large',
+            [classes.railMargin]: leftNavVariant === 'rail',
+          })}
+        >
           <div ref={ref}>
             <Toolbar variant="dense" className={classes.toolbar} disableGutters>
               <div className={classes.leftContent}>
                 <Grid container spacing={1} alignItems="center">
                   <Grid item>
                     <IconButton onClick={handleDrawerOpen} className={classes.menuButton}>
-                      <MenuIcon />
+                      {/* eslint-disable-next-line no-nested-ternary */}
+                      {lg && leftNavVariant === 'large' ? (
+                        <ShrinkIcon />
+                      ) : lg && leftNavVariant === 'rail' ? (
+                        <GrowIcon />
+                      ) : (
+                        <MenuIcon />
+                      )}
                     </IconButton>
                   </Grid>
                   <Grid item>

--- a/client/src/components/Drawer/Drawer.tsx
+++ b/client/src/components/Drawer/Drawer.tsx
@@ -6,7 +6,7 @@ import { useHashMatch, useRouteFind } from 'hooks';
 import React, { useCallback, useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
-import { numUnitsSelector } from 'store/selectors';
+import { numUnitsSelector, useRailLgSelector } from 'store/selectors';
 import { HASHES, ROUTES } from 'utils/urls';
 
 import DrawerLogo from './DrawerLogo';
@@ -47,12 +47,13 @@ const Drawer = () => {
   const classes = useStyles();
 
   const numUnits = useSelector(numUnitsSelector);
+  const useRailLg = useSelector(useRailLgSelector);
 
   const open = useHashMatch(HASHES.DRAWER);
   const [, , page] = useRouteFind(Object.values(ROUTES));
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
   const lg = useMediaQuery(theme.breakpoints.up('lg'));
-  const hasRail = useMediaQuery(theme.breakpoints.only('md'));
+  const md = useMediaQuery(theme.breakpoints.only('md'));
 
   const onSwipeOpen = () => {
     history.push(HASHES.DRAWER);
@@ -70,13 +71,16 @@ const Drawer = () => {
 
   const isHome = [ROUTES.HOME, ROUTES.TARGET, ROUTES.STATS].includes(page);
 
+  const isPermanent = lg && !useRailLg;
+  const useRail = md || (lg && useRailLg);
+
   return (
     <>
-      {hasRail && <Rail />}
+      {useRail && <Rail />}
       <AppDrawer
         open={open}
         onOpen={onSwipeOpen}
-        variant={lg ? 'permanent' : 'temporary'}
+        variant={isPermanent ? 'permanent' : 'temporary'}
         anchor="left"
         onClose={handleClose}
         ModalProps={{

--- a/client/src/components/Drawer/DrawerLogo.tsx
+++ b/client/src/components/Drawer/DrawerLogo.tsx
@@ -1,4 +1,5 @@
 import { makeStyles, Theme } from '@material-ui/core/styles';
+import clsx from 'clsx';
 import { LogoIcon } from 'components/Icons';
 import Link from 'components/Link';
 import React from 'react';
@@ -11,17 +12,21 @@ const useStyles = makeStyles((theme: Theme) => ({
     alignItems: 'center',
     fontSize: '3.5rem',
     display: 'flex',
-    [theme.breakpoints.only('md')]: {
-      margin: theme.spacing(0.5, 0, 1),
-      fontSize: '2.75rem',
-    },
+  },
+  mini: {
+    margin: theme.spacing(0.5, 0, 1),
+    fontSize: '2.75rem',
   },
 }));
 
-const DrawerLogo = () => {
+interface IDrawerLogoProps {
+  mini?: boolean;
+}
+
+const DrawerLogo = ({ mini }: IDrawerLogoProps) => {
   const classes = useStyles();
   return (
-    <Link to={ROUTES.HOME} replace className={classes.logo}>
+    <Link to={ROUTES.HOME} replace className={clsx(classes.logo, { [classes.mini]: mini })}>
       <LogoIcon color="primary" fontSize="inherit" />
     </Link>
   );

--- a/client/src/components/Drawer/Rail.tsx
+++ b/client/src/components/Drawer/Rail.tsx
@@ -67,7 +67,7 @@ const Drawer = () => {
         paperAnchorLeft: classes.docked,
       }}
     >
-      <DrawerLogo />
+      <DrawerLogo mini />
       <Divider />
       <List className={classes.list}>
         <MenuLinkItem to={ROUTES.HOME} label="Home" icon={<Home />} selected={isHome} mini />

--- a/client/src/components/Footer/Footer.tsx
+++ b/client/src/components/Footer/Footer.tsx
@@ -2,7 +2,9 @@ import { Paper, Typography, useMediaQuery } from '@material-ui/core';
 import { makeStyles, useTheme } from '@material-ui/core/styles';
 import clsx from 'clsx';
 import { Github, Reddit, Releases, WarcryStatshammer } from 'components/SocialButtons';
+import { useRouteFind } from 'hooks';
 import React from 'react';
+import { ROUTES } from 'utils/urls';
 
 const useStyles = makeStyles(theme => ({
   footer: {
@@ -42,6 +44,9 @@ const Footer = () => {
   const classes = useStyles();
   const theme = useTheme();
   const mobile = useMediaQuery(theme.breakpoints.down('sm'));
+  const [, , page] = useRouteFind(Object.values(ROUTES));
+
+  if (page === ROUTES.PDF) return null;
 
   return (
     <footer className={classes.footer}>

--- a/client/src/components/SimulationInfoModal/SimulationInfoModal.tsx
+++ b/client/src/components/SimulationInfoModal/SimulationInfoModal.tsx
@@ -26,6 +26,11 @@ const useStyles = makeStyles((theme: Theme) => ({
   closeIcon: {
     marginRight: theme.spacing(1),
   },
+  md: {
+    '& p': {
+      fontSize: '0.75rem',
+    },
+  },
 }));
 
 const SimulationInfoModal = () => {
@@ -67,7 +72,7 @@ const SimulationInfoModal = () => {
           <span>Simulation Info</span>
         </DialogTitle>
         <DialogContent>
-          <ReactMarkdown source={content} />
+          <ReactMarkdown source={content} className={classes.md} />
         </DialogContent>
         <DialogActions>
           <Button variant="contained" color="primary" startIcon={<Close />} onClick={handleClose}>

--- a/client/src/containers/About/About.tsx
+++ b/client/src/containers/About/About.tsx
@@ -49,6 +49,9 @@ const useStyles = makeStyles((theme: Theme) => ({
         color: theme.palette.primary.dark,
       },
     },
+    '& p': {
+      fontSize: '0.75rem',
+    },
   },
   divider: {
     marginTop: theme.spacing(3),

--- a/client/src/containers/Home/DesktopHome.tsx
+++ b/client/src/containers/Home/DesktopHome.tsx
@@ -12,9 +12,11 @@ const useStyles = makeStyles(theme => ({
   desktopHome: {
     display: 'flex',
     flexDirection: 'row',
+    height: '100%',
   },
   tabs: {
     marginTop: 0,
+    height: '100%',
   },
   tab: {
     padding: theme.spacing(2, 0, 2, 2),

--- a/client/src/containers/Home/MobileHome.tsx
+++ b/client/src/containers/Home/MobileHome.tsx
@@ -10,10 +10,12 @@ const useStyles = makeStyles(() => ({
   mobileHome: {
     display: 'flex',
     flex: 1,
+    height: '100%',
   },
   tabs: {
     marginTop: 0,
     maxWidth: '100vw',
+    height: '100%',
   },
   tab: {
     padding: '.5em',

--- a/client/src/containers/Simulations/MetricsTables.tsx
+++ b/client/src/containers/Simulations/MetricsTables.tsx
@@ -22,7 +22,7 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   table: {
     background: theme.palette.background.nested,
-    overflowX: 'scroll',
+    overflowX: 'auto',
   },
   header: {
     fontWeight: theme.typography.fontWeightBold,

--- a/client/src/containers/Stats/ResultsTable.tsx
+++ b/client/src/containers/Stats/ResultsTable.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
   },
   skeleton: {},
   container: {
-    overflowX: 'scroll',
+    overflowX: 'auto',
   },
   sticky: {
     position: 'sticky',

--- a/client/src/store/selectors/configSelectors.ts
+++ b/client/src/store/selectors/configSelectors.ts
@@ -9,3 +9,5 @@ export const desktopGraphListSelector = createSelector(
 );
 
 export const numSimulationsSelector = createSelector(configSelector, ({ numSimulations }) => numSimulations);
+
+export const useRailLgSelector = createSelector(configSelector, ({ useRailLg }) => useRailLg);

--- a/client/src/store/slices/config.ts
+++ b/client/src/store/slices/config.ts
@@ -6,6 +6,7 @@ const INITIAL_STATE: IConfigStore = {
   darkMode: false,
   desktopGraphList: false,
   numSimulations: appConfig.simulations.default,
+  useRailLg: false,
 };
 
 const toggleDarkMode = (state: IConfigStore) => {
@@ -21,6 +22,10 @@ const changeNumSimulations = (state: IConfigStore, action: { payload: { newValue
   state.numSimulations = newValue;
 };
 
+const toggleUseRailLg = (state: IConfigStore) => {
+  state.useRailLg = !state.useRailLg;
+};
+
 export const configStore = createSlice({
   name: 'config',
   initialState: INITIAL_STATE,
@@ -28,5 +33,6 @@ export const configStore = createSlice({
     toggleDarkMode,
     toggleDesktopGraphList,
     changeNumSimulations,
+    toggleUseRailLg,
   },
 });

--- a/client/src/tests/selectors/configSelectors.test.ts
+++ b/client/src/tests/selectors/configSelectors.test.ts
@@ -14,4 +14,8 @@ describe('configSelectors', () => {
   test('numSimulationsSelector', () => {
     expect(selectors.numSimulationsSelector(state)).toEqual(5000);
   });
+
+  test('useRailLgSelector', () => {
+    expect(selectors.useRailLgSelector(state)).toEqual(false);
+  });
 });

--- a/client/src/tests/selectors/utils/testState.ts
+++ b/client/src/tests/selectors/utils/testState.ts
@@ -147,6 +147,7 @@ export const config: IConfigStore = {
   darkMode: false,
   desktopGraphList: false,
   numSimulations: 5000,
+  useRailLg: false,
 };
 
 export const state: IStore = {

--- a/client/src/types/store.ts
+++ b/client/src/types/store.ts
@@ -45,6 +45,8 @@ export interface IConfigStore {
   desktopGraphList: boolean;
   /** The number of simulations to run */
   numSimulations: number;
+  /** Whether to use the rail version of the left navigation for lg breakpoints */
+  useRailLg: boolean;
 }
 
 export interface IStore {


### PR DESCRIPTION
## UI

- Minor UI Tweaks / Improvements (fixes #43)
    - Remove Footer from /pdf page (takes up too much space)
    - Change `overflow-x: scroll` -> `overflow-x: auto` on tables
    - Increase font-size on `/about` page for non-retina displays
    - Tabs touch scrolling is currently shrinking to content height
    - Users should be able to change between full and rail version of the left navigation when in large (lg) mode