### PR TITLE
Fix max damage calculations when you mix exploding with conditional bonus

### DIFF
--- a/api/constants.ts
+++ b/api/constants.ts
@@ -15,4 +15,10 @@ export const getCharacteristic = (val: string): Characteristic | null => {
   return null;
 };
 
+export const getCharacteristicsAfter = (characteristic: Characteristic): Characteristic[] => {
+  const values = Object.keys(Characteristic).map((key) => Characteristic[key]);
+  const index = values.indexOf(characteristic);
+  return values.slice(index + 1);
+};
+
 export const SAVES = [2, 3, 4, 5, 6, 0];

--- a/api/processors/maxDamageProcessor.ts
+++ b/api/processors/maxDamageProcessor.ts
@@ -1,4 +1,4 @@
-import { Characteristic as C, Characteristic, getCharacteristicsAfter } from '../constants';
+import { Characteristic as C, getCharacteristicsAfter } from '../constants';
 import { MODIFIERS as m } from '../models/modifiers';
 import type WeaponProfile from '../models/weaponProfile';
 
@@ -73,14 +73,6 @@ export default class MaxDamageProcessor {
       }
     });
     return bonus;
-  }
-
-  private resolveExplodingModifiers(numAttacks: number): number {
-    return m.EXPLODING.availableCharacteristics.reduce((acc, c) => {
-      const mod = this.profile.modifiers.getModifier(m.EXPLODING, c);
-      if (mod && mod.extraHits.max > 0) return acc + numAttacks * mod.extraHits.max;
-      return acc;
-    }, 0);
   }
 
   private resolveMortalWounds(currentMax: number): number {

--- a/api/tests/maxDamageProcessor.test.ts
+++ b/api/tests/maxDamageProcessor.test.ts
@@ -52,4 +52,9 @@ describe('MaxDamageProcessor', () => {
   test('Rattling Gunners', () => {
     expect(u.rattlingGunners.maxDamage()).toEqual(12);
   });
+
+  test('Edge Cases', () => {
+    expect(u.explodingAndConditionalSame.maxDamage()).toEqual(21);
+    expect(u.explodingAndConditionalDifferent.maxDamage()).toEqual(27);
+  });
 });

--- a/api/tests/utils/units.ts
+++ b/api/tests/utils/units.ts
@@ -130,3 +130,42 @@ export const plagueMonksOld = new Unit('Plague Monks (pre Dec 2019 FAQ)', [
 export const rattlingGunners = new Unit('Rattling Gunners', [
   new WeaponProfile(1, DiceValue.parse('2D6'), 4, 4, 1, 1, []),
 ]);
+
+// #region edge cases
+export const explodingAndConditionalSame = new Unit('Exploding And Conditional (Same Characteristic)', [
+  new WeaponProfile(1, 3, 3, 4, 1, 2, [
+    new m.EXPLODING({
+      characteristic: C.TO_HIT,
+      on: 6,
+      extraHits: 2,
+      unmodified: true,
+    }),
+    new m.CONDITIONAL_BONUS({
+      characteristic: C.TO_HIT,
+      bonus: 1,
+      unmodified: true,
+      bonusToCharacteristic: C.DAMAGE,
+    }),
+  ]),
+]);
+
+export const explodingAndConditionalDifferent = new Unit(
+  'Exploding And Conditional (Different Characteristic)',
+  [
+    new WeaponProfile(1, 3, 3, 4, 1, 2, [
+      new m.EXPLODING({
+        characteristic: C.TO_HIT,
+        on: 6,
+        extraHits: 2,
+        unmodified: true,
+      }),
+      new m.CONDITIONAL_BONUS({
+        characteristic: C.TO_WOUND,
+        bonus: 1,
+        unmodified: true,
+        bonusToCharacteristic: C.DAMAGE,
+      }),
+    ]),
+  ],
+);
+// #endregion

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "private": true,
     "proxy": "http://localhost:5000/",
     "dependencies": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
         "*",
         "."
     ],
-    "version": "2.1.0",
+    "version": "2.1.1",
     "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "statshammer-express",
     "private": true,
-    "version": "2.1.0",
+    "version": "2.1.1",
     "engines": {
         "node": "12.16.3",
         "yarn": "1.22.4"


### PR DESCRIPTION
## Fixes

- Fix max damage calculations when you mix exploding modifier with conditional bonus modifier (that applies on the same characteristic)
    - It was incorrectly applying the conditional bonus to the exploded values