### PR TITLE
Fix cropping of max damage on discrete probability graphs

### DIFF
--- a/api/controllers/statsController.ts
+++ b/api/controllers/statsController.ts
@@ -82,15 +82,17 @@ export default class StatsController {
 
   private buildSimulationResult(data: TMappedResult): ISimulationResult {
     const unitNames = Object.keys(data.results);
+    const metrics = this.buildSimulationMetrics(data);
+    const maxDamage = Math.max(...Object.keys(metrics.max).map((name) => metrics.max[name]));
     const mappedProbabilities = Object.keys(data.results).reduce<TMappedProbabilities>((acc, name) => {
       data.results[name].buckets.forEach(({ damage, probability }) => {
+        if (damage > maxDamage) return;
         if (acc[damage] == null) acc[damage] = {};
         acc[damage][name] = probability;
       });
       return acc;
     }, {});
 
-    const metrics = this.buildSimulationMetrics(data);
     const discrete = this.buildDiscreteProbabilities(mappedProbabilities);
     const cumulative = this.buildCumulativeProbabilities(mappedProbabilities, unitNames, metrics);
     return { save: data.save, discrete, cumulative, metrics };

--- a/api/models/unit.ts
+++ b/api/models/unit.ts
@@ -107,7 +107,10 @@ class Unit {
     [...range(sampleMax + 1, max, step)].forEach((i) => {
       buckets.push({ damage: i, count: 0, probability: 0 });
     });
-    buckets.push({ damage: max, count: 0, probability: 0 });
+    if (sampleMax < max) {
+      buckets.push({ damage: max, count: 0, probability: 0 });
+    }
+    buckets.push({ damage: max + 1, count: 0, probability: 0 });
 
     return buckets;
   }

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "statshammer",
-    "version": "2.1.1",
+    "version": "2.1.2",
     "private": true,
     "proxy": "http://localhost:5000/",
     "dependencies": {

--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
         "*",
         "."
     ],
-    "version": "2.1.1",
+    "version": "2.1.2",
     "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "statshammer-express",
     "private": true,
-    "version": "2.1.1",
+    "version": "2.1.2",
     "engines": {
         "node": "12.16.3",
         "yarn": "1.22.4"


### PR DESCRIPTION
## Fixes

- Fix for the max damage of a profile was being forced to 0 when creating the discrete probability graphs